### PR TITLE
[BLOG-24] 블로그글 아이콘 뿐만 아니라 커버 사진도 렌더링 기능하게 하는 기능

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,8 +1,9 @@
 import Blog from "@/components/Blog";
 import { getBlogPosts } from "@/lib/notion/blog";
 
-// 1시간마다 백그라운드 재생성 (ISR) — 방문마다 Notion을 호출하지 않는다
-export const revalidate = 3600;
+// 30분마다 백그라운드 재생성 (ISR) — Notion 커버 이미지 URL 만료(약 1시간)보다
+// 짧게 유지해 깨진 이미지를 방지한다
+export const revalidate = 1800;
 
 export default async function BlogPage() {
   const posts = await getBlogPosts();

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -4,7 +4,8 @@ import { notFound } from "next/navigation";
 import BlogPost from "@/components/BlogPost";
 import { getBlogPostById } from "@/lib/notion/blog";
 
-export const revalidate = 3600;
+// Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
+export const revalidate = 1800;
 
 // generateMetadata와 페이지 렌더링이 같은 요청을 공유하도록 캐싱
 const getPost = cache(getBlogPostById);
@@ -34,11 +35,13 @@ export async function generateMetadata({
       type: "article",
       publishedTime: post.date,
       tags: post.tags,
+      ...(post.cover && { images: [{ url: post.cover }] }),
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description,
+      ...(post.cover && { images: [post.cover] }),
     },
   };
 }

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -114,14 +114,26 @@ export default function Blog({ posts }: BlogProps) {
               >
                 <article>
                   <div
-                    className={`h-48 bg-linear-to-br ${post.color} flex items-center justify-center relative overflow-hidden`}
+                    className={`h-48 flex items-center justify-center relative overflow-hidden ${
+                      post.cover ? "" : `bg-linear-to-br ${post.color}`
+                    }`}
                   >
+                    {post.cover && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={post.cover}
+                        alt=""
+                        className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform"
+                      />
+                    )}
                     <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
-                    <Icon
-                      name={getCategoryIcon(post.category)}
-                      size={52}
-                      className="text-white drop-shadow-md group-hover:scale-110 transition-transform relative z-10"
-                    />
+                    {!post.cover && (
+                      <Icon
+                        name={getCategoryIcon(post.category)}
+                        size={52}
+                        className="text-white drop-shadow-md group-hover:scale-110 transition-transform relative z-10"
+                      />
+                    )}
                   </div>
 
                   <div className="p-6">

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -90,11 +90,21 @@ export default function BlogPost({ post }: Props) {
 
       {/* Hero */}
       <motion.div
-        className={`relative h-80 bg-linear-to-br ${post.color} overflow-hidden mb-12`}
+        className={`relative h-80 overflow-hidden mb-12 ${
+          post.cover ? "" : `bg-linear-to-br ${post.color}`
+        }`}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.6 }}
       >
+        {post.cover && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={post.cover}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+        )}
         <div className="absolute inset-0 bg-black/20" />
         <div className="absolute inset-0 bg-linear-to-t from-black/60 via-black/20 to-transparent" />
 

--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -18,6 +18,8 @@ function mapPageToBlogPost(page: any): BlogPost {
     color: getColorGradient(props.Color?.select?.name || "Blue"),
     releasable: props.Published?.checkbox || false,
     likes: props.Likes?.number || 0,
+    // Notion 업로드 파일 URL은 만료가 있으므로(약 1시간) ISR 주기를 그보다 짧게 유지할 것
+    cover: page.cover?.external?.url || page.cover?.file?.url || "",
   };
 }
 

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -12,6 +12,8 @@ export interface BlogPost {
   releasable: boolean;
   content?: string;
   likes: number;
+  /** Notion 페이지 커버 이미지 URL (없으면 빈 문자열 → 그라디언트 폴백) */
+  cover: string;
 }
 
 export interface Project {


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #26 → #27 → #28 → #29 → 이 PR.

## 요약

이슈 #24: Notion CMS에서 페이지 커버 사진을 가져와 글 커버로 사용합니다.

## 변경 내용

### 데이터 (`lib/notion/blog.ts`, `lib/notion/types.ts`)
- `BlogPost.cover` 필드 추가 — Notion `page.cover`에서 추출 (`external.url` 우선, 업로드 파일이면 `file.url`, 없으면 빈 문자열)
- 목록·상세 매핑이 `mapPageToBlogPost()` 한 곳이라 이 함수만 수정하면 양쪽에 반영됨

### 렌더링
- **블로그 카드** (`components/Blog.tsx`): 커버가 있으면 `object-cover` 이미지 (hover 시 살짝 확대), 없으면 기존 카테고리 그라디언트 + 아이콘 폴백 유지
- **포스트 히어로** (`components/BlogPost.tsx`): 커버 이미지 위에 기존 다크 스크림(제목 가독성용)을 그대로 얹음 — 커버 없는 글은 기존과 동일

### SEO (`app/blog/post/[id]/page.tsx`)
- 커버가 있으면 `og:image` / `twitter:image`로 노출 — 링크 공유 시 미리보기 이미지

### ISR 주기 단축 (3600s → 1800s)
Notion에 **업로드된** 파일의 URL은 약 1시간 만료되는 서명 URL입니다. 페이지 캐시가 1시간이면 만료 직전 캐시에서 깨진 이미지가 보일 수 있어, 블로그 목록·상세의 revalidate를 30분으로 줄여 URL이 항상 유효 기간 내에 있도록 했습니다. (외부 URL 커버는 만료 없음)

## 검증
- `tsc --noEmit` 통과, ESLint 에러 0, `/blog`·포스트 페이지 200 및 폴백 렌더링 확인
- 현재 Notion 글 47개 모두 커버 미설정이라 실이미지 검증은 못 함 — **Notion에서 아무 글에나 커버를 설정하면 30분 내(또는 재배포 시 즉시) 반영됩니다.** 라이브 CMS 수정은 권한상 하지 않았습니다.

Resolves #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)