### PR TITLE
[BLOG-15] [ENHANCE] 반응형 UI 확인

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,9 @@ export default function RootLayout({
       >
         <MotionConfig reducedMotion="user">
           <Header />
-          <main className="pt-20">{children}</main>
+          {/* pt-24: 고정 헤더(모바일 80px/데스크톱 88px)에 본문이 가리지 않도록
+              overflow-x-clip: About 히어로의 데코 블러 원이 모바일 가로 스크롤을 만들지 않도록 */}
+          <main className="pt-24 overflow-x-clip">{children}</main>
           <Footer />
         </MotionConfig>
       </body>

--- a/components/AboutMe/HeroSection.tsx
+++ b/components/AboutMe/HeroSection.tsx
@@ -6,7 +6,7 @@ export default function HeroSection() {
     <div className="grid md:grid-cols-2 gap-12 items-center mb-24">
       <div>
         <div>
-          <h2 className="mb-6">
+          <h2 className="mb-6 break-keep">
             <span className="block text-yellow-500">긍정적인</span>
             <span>사고를 바탕으로</span>
             <span className=" text-green-500">성장 </span>

--- a/components/AboutMe/ProjectModal.tsx
+++ b/components/AboutMe/ProjectModal.tsx
@@ -78,7 +78,7 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
         </div>
 
         {/* Content */}
-        <div className="p-8 md:p-10">
+        <div className="p-6 sm:p-8 md:p-10">
           {/* Tags */}
           <div className="flex flex-wrap gap-2 mb-8 pb-6 border-b border-gray-200">
             {project.tags

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -64,7 +64,7 @@ export default function Blog({ posts }: BlogProps) {
       <div className="flex flex-col lg:flex-row gap-8">
         {/* Sidebar */}
         <aside className="lg:w-64 shrink-0">
-          <div className="bg-white rounded-2xl shadow-lg p-6 sticky top-24">
+          <div className="bg-white rounded-2xl shadow-lg p-6 lg:sticky lg:top-28">
             <h3 className="mb-6 flex items-center gap-2">
               <Icon name="book" size={22} className="text-orange-500" />
               <span>Categories</span>

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -114,15 +114,15 @@ export default function BlogPost({ post }: Props) {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.2 }}
           >
-            <div className="flex items-center gap-3 mb-4">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mb-4">
               <span className="px-4 py-1.5 bg-white/90 backdrop-blur-sm text-gray-800 rounded-full">
                 {post.category}
               </span>
               <span className="text-white/90">읽는데 {post.readTime}분</span>
-              <span className="text-white/90">•</span>
+              <span className="text-white/90 hidden sm:inline">•</span>
               <span className="text-white/90">{post.date}</span>
             </div>
-            <h1 className="text-white mb-0 text-4xl md:text-5xl">
+            <h1 className="text-white mb-0 text-3xl sm:text-4xl md:text-5xl break-keep">
               {post.title}
             </h1>
           </motion.div>
@@ -239,7 +239,9 @@ export default function BlogPost({ post }: Props) {
                 <hr className="my-8 border-gray-200" {...props} />
               ),
               table: ({ ...props }) => (
-                <table className="w-full my-6 border-collapse" {...props} />
+                <div className="overflow-x-auto my-6">
+                  <table className="w-full border-collapse" {...props} />
+                </div>
               ),
               thead: ({ ...props }) => (
                 <thead className="bg-gray-50" {...props} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,21 +11,21 @@ export default function Header() {
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-orange-100">
-      <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
         <Link
           href="/about"
-          className="flex items-center gap-3 cursor-pointer hover:opacity-80 transition-opacity"
+          className="flex items-center gap-2 sm:gap-3 cursor-pointer hover:opacity-80 transition-opacity min-w-0"
         >
-          <div className="w-14 h-14 bg-linear-to-br from-orange-400 to-red-100 rounded-full flex items-center justify-center shadow-lg">
+          <div className="w-12 h-12 sm:w-14 sm:h-14 shrink-0 bg-linear-to-br from-orange-400 to-red-100 rounded-full flex items-center justify-center shadow-lg">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src="/images/logo.svg" alt="로고" />
           </div>
-          <h1 className="font-bold text-2xl bg-linear-to-r from-orange-600 to-red-600 bg-clip-text text-transparent">
+          <h1 className="font-bold text-xl sm:text-2xl bg-linear-to-r from-orange-600 to-red-600 bg-clip-text text-transparent truncate">
             JSChoIog!
           </h1>
         </Link>
 
-        <nav className="flex gap-2">
+        <nav className="flex gap-1 sm:gap-2 shrink-0">
           <NavLink active={isBlog} href="/blog">
             Blog
           </NavLink>
@@ -50,7 +50,7 @@ function NavLink({
   return (
     <Link
       href={href}
-      className={`px-6 py-2 rounded-full transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center ${
+      className={`px-4 sm:px-6 py-2 rounded-full transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center whitespace-nowrap ${
         active
           ? "bg-linear-to-r from-orange-500 to-red-500 text-white shadow-lg"
           : "text-gray-700 hover:bg-orange-50"


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #26 → #27 → #28 → #29 → #31 → #32 → 이 PR.

## 요약

이슈 #15 "반응형으로 글자 밀리는 문제 등 이상한 부분들 수정". 코드 분석으로 찾은 실제 레이아웃 결함 7건입니다.

## 변경 내용 (문제 → 수정)

1. **본문 상단이 헤더에 가림** — 고정 헤더 실제 높이가 88px(py-4 32px + 로고 56px)인데 본문 오프셋이 `pt-20`(80px)이라 첫 8px이 항상 가려져 있었음 → `pt-24`로 수정 (`app/layout.tsx`)
2. **모바일 가로 스크롤** — About 히어로의 장식용 블러 원(`w-72`, `-right-4` absolute)이 뷰포트 밖으로 뻗어 모바일에서 body가 옆으로 밀렸음 → `main`에 `overflow-x-clip` (`app/layout.tsx`)
3. **모바일 헤더 오버플로** — 56px 로고 + text-2xl 워드마크 + 필 2개가 375px 화면에서 넘침 → 로고 `w-12 sm:w-14`, 워드마크 `text-xl sm:text-2xl` + `truncate`, 네비 필 `px-4 sm:px-6` + `whitespace-nowrap` (`components/Header.tsx`)
4. **포스트 히어로 메타 줄 넘침** — 카테고리 칩 + 읽는 시간 + 날짜가 좁은 화면에서 한 줄에 안 들어감 → `flex-wrap` + 모바일에서 구분점(•) 숨김. 제목도 `text-3xl sm:text-4xl md:text-5xl` + **`break-keep`** (한국어 어절 단위 줄바꿈 — "글자 밀리는 문제"의 핵심 수정) (`components/BlogPost.tsx`)
5. **마크다운 표가 본문을 밀어냄** — 넓은 표가 컨테이너를 뚫고 나갔음 → `overflow-x-auto` 래퍼로 표만 가로 스크롤 (`components/BlogPost.tsx`)
6. **모바일에서 카테고리 사이드바 sticky** — 세로 스택 상태에서 사이드바가 스크롤을 따라와 목록을 가렸음 → `lg:sticky`로 데스크톱 한정 (`components/Blog.tsx`)
7. **잔손질** — 프로젝트 모달 모바일 패딩 `p-6 sm:p-8 md:p-10`, About 히어로 제목 `break-keep`

## 검증
- `tsc --noEmit` 통과, ESLint 에러 0, 전 페이지(/, /blog, 포스트, /about) 정상 응답
- 코드 분석 기반 수정이므로 **머지 전 Vercel 프리뷰를 실기기(또는 devtools 모바일 뷰포트 375px)로 한 번 확인 권장**

Resolves #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)