### PR TITLE
Feat: 헤더 로고 클릭 시 Blog로 이동

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
     <header className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-orange-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
         <Link
-          href="/about"
+          href="/blog"
           className="flex items-center gap-2 sm:gap-3 cursor-pointer hover:opacity-80 transition-opacity min-w-0"
         >
           <div className="w-12 h-12 sm:w-14 sm:h-14 shrink-0 bg-linear-to-br from-orange-400 to-red-100 rounded-full flex items-center justify-center shadow-lg">


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #29 → #31 → #32 → #33 → 이 PR.

## 요약

헤더 로고(홈 버튼) 클릭 시 이동 경로를 `/about` → `/blog`로 변경.

참고: 사이트 루트(`/`) 접속 시 리다이렉트는 여전히 `/about`(랜딩)입니다. 루트도 Blog로 바꾸길 원하면 `app/page.tsx`의 `redirect("/about")` 한 줄만 바꾸면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)