### PR TITLE
Design: About Me 리디자인 — 여정 타임라인 중심 (시안 B)

### DIFF
--- a/.claude/skills/design-sync/generate.js
+++ b/.claude/skills/design-sync/generate.js
@@ -403,6 +403,46 @@ const out = (rel, html) => {
   );
 }
 
+/* ---------- patterns/about-journey ---------- */
+{
+  const body = `
+  <p class="sub">About Me 페이지 패턴 (시안 B 채택) — 컴팩트 히어로 + 여정 타임라인 + 도구 칩</p>
+  <div class="hero-row">
+    <div class="ava">JS</div>
+    <div>
+      <div class="name">최준서 <span class="gtext">— 긍정을 전파하는 개발자</span></div>
+      <div class="tag">다양한 분야의 팀원들과 함께 만드는 과정을 좋아합니다</div>
+    </div>
+  </div>
+  <div class="section">여정 타임라인</div>
+  <div class="tl">
+    <div class="tli"><b>2026</b><span>AI·SW마에스트로 17기 합격</span></div>
+    <div class="tli"><b>2025.06 – 08</b><span>WINEQUEEN 출시</span></div>
+    <div class="tli"><b>2025.06 ~</b><span>프로젝트 당번</span></div>
+    <div class="tli"><b>2025 ~</b><span>기술 블로그 · 알고리즘 연재</span></div>
+  </div>
+  <div class="section">도구 칩 (% 바 제거)</div>
+  <div class="chips"><span>React</span><span>TypeScript</span><span>Tailwind CSS</span><span>Next.js</span><span>HTML5</span></div>`;
+
+  out(
+    "patterns/about-journey.html",
+    page("Patterns", "About · Journey", body, `
+    .hero-row { display: flex; align-items: center; gap: 14px; margin-bottom: 6px; }
+    .ava { width: 56px; height: 56px; border-radius: 999px; background: linear-gradient(135deg, ${BRAND.orange300}, ${BRAND.red400}); display: grid; place-items: center; color: #fff; font-weight: 800; font-size: 18px; box-shadow: 0 0 0 2px ${BRAND.orange200}; }
+    .name { font-size: 17px; font-weight: 800; color: ${GRAY.g800}; }
+    .gtext { background: linear-gradient(90deg, ${BRAND.orange600}, ${BRAND.red600}); -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .tag { font-size: 12px; color: ${GRAY.g500}; }
+    .tl { position: relative; padding-left: 22px; max-width: 420px; }
+    .tl::before { content: ""; position: absolute; left: 6px; top: 4px; bottom: 4px; width: 2px; border-radius: 2px; background: linear-gradient(${BRAND.orange400}, ${BRAND.red400}); }
+    .tli { position: relative; padding-bottom: 12px; }
+    .tli::before { content: ""; position: absolute; left: -21px; top: 4px; width: 9px; height: 9px; border-radius: 999px; background: ${BRAND.orange500}; box-shadow: 0 0 0 3px ${BRAND.orange100}; }
+    .tli b { display: block; font-size: 11px; color: ${BRAND.orange600}; }
+    .tli span { font-size: 13px; font-weight: 600; color: ${GRAY.g800}; }
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+    .chips span { background: #fff; border-radius: 10px; padding: 8px 14px; font-size: 13px; font-weight: 500; color: ${GRAY.g700}; box-shadow: 0 2px 6px -2px rgb(0 0 0/.15); }`)
+  );
+}
+
 /* ---------- components/icons ---------- */
 {
   const SET = [

--- a/.claude/skills/design-sync/out/patterns/about-journey.html
+++ b/.claude/skills/design-sync/out/patterns/about-journey.html
@@ -1,0 +1,46 @@
+<!-- @dsCard group="Patterns" -->
+<!doctype html>
+<meta charset="utf-8">
+<title>About · Journey</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Apple SD Gothic Neo', sans-serif; background: linear-gradient(135deg, #fff7ed, #fffbeb, #fefce8); color: #1f2937; padding: 24px; }
+  h1 { font-size: 18px; font-weight: 600; margin-bottom: 4px; }
+  .sub { font-size: 12px; color: #6b7280; margin-bottom: 20px; }
+  .section { font-size: 12px; font-weight: 600; color: #6b7280; margin: 20px 0 8px; text-transform: uppercase; letter-spacing: .04em; }
+  
+    .hero-row { display: flex; align-items: center; gap: 14px; margin-bottom: 6px; }
+    .ava { width: 56px; height: 56px; border-radius: 999px; background: linear-gradient(135deg, #fdba74, #f87171); display: grid; place-items: center; color: #fff; font-weight: 800; font-size: 18px; box-shadow: 0 0 0 2px #fed7aa; }
+    .name { font-size: 17px; font-weight: 800; color: #1f2937; }
+    .gtext { background: linear-gradient(90deg, #ea580c, #dc2626); -webkit-background-clip: text; background-clip: text; color: transparent; }
+    .tag { font-size: 12px; color: #6b7280; }
+    .tl { position: relative; padding-left: 22px; max-width: 420px; }
+    .tl::before { content: ""; position: absolute; left: 6px; top: 4px; bottom: 4px; width: 2px; border-radius: 2px; background: linear-gradient(#fb923c, #f87171); }
+    .tli { position: relative; padding-bottom: 12px; }
+    .tli::before { content: ""; position: absolute; left: -21px; top: 4px; width: 9px; height: 9px; border-radius: 999px; background: #f97316; box-shadow: 0 0 0 3px #ffedd5; }
+    .tli b { display: block; font-size: 11px; color: #ea580c; }
+    .tli span { font-size: 13px; font-weight: 600; color: #1f2937; }
+    .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+    .chips span { background: #fff; border-radius: 10px; padding: 8px 14px; font-size: 13px; font-weight: 500; color: #374151; box-shadow: 0 2px 6px -2px rgb(0 0 0/.15); }
+</style>
+<body>
+<h1>About · Journey</h1>
+
+  <p class="sub">About Me 페이지 패턴 (시안 B 채택) — 컴팩트 히어로 + 여정 타임라인 + 도구 칩</p>
+  <div class="hero-row">
+    <div class="ava">JS</div>
+    <div>
+      <div class="name">최준서 <span class="gtext">— 긍정을 전파하는 개발자</span></div>
+      <div class="tag">다양한 분야의 팀원들과 함께 만드는 과정을 좋아합니다</div>
+    </div>
+  </div>
+  <div class="section">여정 타임라인</div>
+  <div class="tl">
+    <div class="tli"><b>2026</b><span>AI·SW마에스트로 17기 합격</span></div>
+    <div class="tli"><b>2025.06 – 08</b><span>WINEQUEEN 출시</span></div>
+    <div class="tli"><b>2025.06 ~</b><span>프로젝트 당번</span></div>
+    <div class="tli"><b>2025 ~</b><span>기술 블로그 · 알고리즘 연재</span></div>
+  </div>
+  <div class="section">도구 칩 (% 바 제거)</div>
+  <div class="chips"><span>React</span><span>TypeScript</span><span>Tailwind CSS</span><span>Next.js</span><span>HTML5</span></div>
+</body>

--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import HeroSection from "./AboutMe/HeroSection";
+import JourneySection from "./AboutMe/JourneySection";
 import SkillsSection from "./AboutMe/SkillsSection";
 import ProjectsSection from "./AboutMe/ProjectsSection";
 import ProjectModal from "./AboutMe/ProjectModal";
@@ -11,7 +12,6 @@ import type { Project, Skill } from "@/lib/notion/types";
 const skills: Skill[] = [
   {
     name: "React",
-    level: 40,
     icon: (
       <svg
         role="img"
@@ -26,7 +26,6 @@ const skills: Skill[] = [
   },
   {
     name: "TypeScript",
-    level: 35,
     icon: (
       <svg
         role="img"
@@ -41,7 +40,6 @@ const skills: Skill[] = [
   },
   {
     name: "Tailwind CSS",
-    level: 55,
     icon: (
       <svg
         role="img"
@@ -56,7 +54,6 @@ const skills: Skill[] = [
   },
   {
     name: "NextJS",
-    level: 20,
     icon: (
       <svg
         role="img"
@@ -71,7 +68,6 @@ const skills: Skill[] = [
   },
   {
     name: "HTML5",
-    level: 60,
     icon: (
       <svg
         role="img"
@@ -104,6 +100,7 @@ export default function AboutMe({ projects }: AboutMeProps) {
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
       <HeroSection />
+      <JourneySection />
       <SkillsSection skills={skills} />
       <ProjectsSection
         projects={displayProjects}

--- a/components/AboutMe/HeroSection.tsx
+++ b/components/AboutMe/HeroSection.tsx
@@ -1,55 +1,29 @@
 import Image from "next/image";
-import Icon from "@/components/icons";
 
 export default function HeroSection() {
   return (
-    <div className="grid md:grid-cols-2 gap-12 items-center mb-24">
-      <div>
-        <div>
-          <h2 className="mb-6 break-keep">
-            <span className="block text-yellow-500">긍정적인</span>
-            <span>사고를 바탕으로</span>
-            <span className=" text-green-500">성장 </span>
-            <span>하는 개발자</span>
-            <span className="block">최준서입니다! 👋</span>
-          </h2>
-        </div>
-
-        <p className="text-gray-700 leading-relaxed mb-8">
-          항상 프로젝트에서 다양한 분야의 팀원들과 협력하고 재밌게 함께 만들어
-          나가는 걸 기대하고 있습니다! 저는 긍정적인 사람으로 팀프로젝트에서도
-          제 긍정적인 분위기를 팀원들에게 전달하는 역할을 수행할 수 있을
-          것이라고 생각합니다!
-        </p>
-
-        <div className="flex flex-wrap gap-3">
-          <div className="flex items-center gap-2 px-4 py-2 bg-linear-to-r from-orange-100 to-red-100 rounded-full">
-            <Icon name="target" size={16} className="text-orange-600" />
-            <span className="text-gray-800">팀워크</span>
-          </div>
-          <div className="flex items-center gap-2 px-4 py-2 bg-linear-to-r from-yellow-100 to-orange-100 rounded-full">
-            <Icon name="bulb" size={16} className="text-amber-600" />
-            <span className="text-gray-800">문제 해결</span>
-          </div>
-          <div className="flex items-center gap-2 px-4 py-2 bg-linear-to-r from-green-100 to-emerald-100 rounded-full">
-            <Icon name="rocket" size={16} className="text-emerald-600" />
-            <span className="text-gray-800">빠른 학습</span>
-          </div>
-        </div>
+    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6 mb-20">
+      <div className="relative w-24 h-24 shrink-0 rounded-full overflow-hidden shadow-lg ring-2 ring-orange-200">
+        <Image
+          src="/images/profile3.webp"
+          alt="최준서 프로필"
+          fill
+          sizes="96px"
+          className="object-cover"
+        />
       </div>
-
-      <div className="relative">
-        <div className="relative z-10 rounded-3xl overflow-hidden shadow-2xl">
-          <Image
-            src="/images/profile3.webp"
-            alt="Profile"
-            width={400}
-            height={400}
-            className="w-full h-auto"
-          />
-        </div>
-        <div className="absolute -top-4 -right-4 w-72 h-72 bg-linear-to-br from-orange-300 to-red-300 rounded-full blur-3xl opacity-30 -z-10" />
-        <div className="absolute -bottom-4 -left-4 w-72 h-72 bg-linear-to-br from-yellow-300 to-orange-300 rounded-full blur-3xl opacity-30 -z-10" />
+      <div>
+        <h2 className="mb-2 break-keep">
+          최준서{" "}
+          <span className="bg-linear-to-r from-orange-600 to-red-600 bg-clip-text text-transparent">
+            — 긍정을 전파하는 개발자
+          </span>
+        </h2>
+        <p className="text-gray-700 leading-relaxed break-keep max-w-2xl">
+          다양한 분야의 팀원들과 함께 만드는 과정을 좋아합니다. 프로젝트의
+          분위기를 끌어올리는 역할을 맡아 왔고, 지금은 SW마에스트로 17기에서
+          팀 프로젝트를 준비하고 있습니다.
+        </p>
       </div>
     </div>
   );

--- a/components/AboutMe/JourneySection.tsx
+++ b/components/AboutMe/JourneySection.tsx
@@ -1,0 +1,47 @@
+import Icon from "@/components/icons";
+
+// 사실 기반 여정 — 새 이력이 생기면 맨 앞에 추가
+const journey = [
+  {
+    when: "2026",
+    title: "AI·SW마에스트로 17기 합격",
+    desc: "연수 과정 시작 — 팀 프로젝트 준비 중",
+  },
+  {
+    when: "2025.06 – 2025.08",
+    title: "WINEQUEEN 출시",
+    desc: "Next.js · Supabase — AI 와인 추천 플랫폼 풀스택 개발",
+  },
+  {
+    when: "2025.06 ~",
+    title: "프로젝트 당번",
+    desc: "React · TypeScript — 팀 당번 배정 자동화 서비스",
+  },
+  {
+    when: "2025 ~",
+    title: "기술 블로그 · 알고리즘 연재",
+    desc: "Notion CMS 블로그 직접 구축, 백준 풀이 기록",
+  },
+];
+
+export default function JourneySection() {
+  return (
+    <div className="mb-24">
+      <h3 className="mb-8 flex items-center gap-3">
+        <Icon name="rocket" size={30} className="text-orange-500" />
+        <span>여정</span>
+      </h3>
+      <div className="relative pl-8 max-w-2xl">
+        <div className="absolute left-[7px] top-1 bottom-1 w-0.5 bg-linear-to-b from-orange-400 to-red-400 rounded-full" />
+        {journey.map((item) => (
+          <div key={item.title} className="relative pb-8 last:pb-0">
+            <span className="absolute -left-8 top-1.5 w-4 h-4 rounded-full bg-orange-500 ring-4 ring-orange-100" />
+            <p className="text-sm font-semibold text-orange-600">{item.when}</p>
+            <h4 className="text-gray-900">{item.title}</h4>
+            <p className="text-gray-600 text-sm break-keep">{item.desc}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/AboutMe/SkillsSection.tsx
+++ b/components/AboutMe/SkillsSection.tsx
@@ -1,15 +1,11 @@
 import Icon from "@/components/icons";
-
-interface Skill {
-  name: string;
-  level: number;
-  icon: React.ReactNode;
-}
+import type { Skill } from "@/lib/notion/types";
 
 interface SkillsSectionProps {
   skills: Skill[];
 }
 
+// 숙련도 수치(% 바) 없이 도구 목록만 — 근거 없는 숫자는 신뢰를 깎는다
 export default function SkillsSection({ skills }: SkillsSectionProps) {
   return (
     <div className="mb-24">
@@ -17,25 +13,14 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
         <Icon name="code" size={30} className="text-orange-500" />
         <span>Skills</span>
       </h3>
-      <div className="grid md:grid-cols-2 gap-6">
+      <div className="flex flex-wrap gap-3">
         {skills.map((skill) => (
           <div
             key={skill.name}
-            className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-xl hover:scale-105 transition-all"
+            className="flex items-center gap-2.5 bg-white rounded-xl px-4 py-2.5 shadow-md hover:shadow-lg transition-shadow"
           >
-            <div className="flex items-center justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <span className="text-2xl">{skill.icon}</span>
-                <span className="font-medium text-gray-800">{skill.name}</span>
-              </div>
-              <span className="text-orange-600">{skill.level}%</span>
-            </div>
-            <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-linear-to-r from-orange-400 to-red-500 transition-all duration-1000"
-                style={{ width: `${skill.level}%` }}
-              />
-            </div>
+            {skill.icon}
+            <span className="font-medium text-gray-800">{skill.name}</span>
           </div>
         ))}
       </div>

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -29,6 +29,5 @@ export interface Project {
 
 export interface Skill {
   name: string;
-  level: number;
   icon: ReactNode;
 }


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #29 → #31 → #32 → #33 → #34 → 이 PR.

## 요약

"About Me가 AI가 만든 것 같다"는 진단에서 출발한 리디자인. [시안 3종 비교](https://claude.ai/code/artifact/bdcdee7a-be8c-4781-934f-6eb969acd8b7) 중 **B안(스토리 타임라인)** 채택.

## 진단 → 수정

| AI 티 나던 요소 | 수정 |
|---|---|
| Skill % 바 ("Next.js 20%") — 근거 없는 수치 | % 삭제, 도구 칩 나열로 (`SkillsSection` 재작성) |
| 제목의 무지개 강조 (노랑·초록 span) | 브랜드 그라디언트 강조 한 곳으로 (`HeroSection` 재작성) |
| 미덕 칩 (팀워크·문제해결·빠른학습) | 삭제 — 미덕은 주장 대신 여정의 사실로 증명 |
| 사진 뒤 블러 원 2개 | 삭제 — 원형 프로필 + 링 프레임 |
| 느낌표 연속 카피 | 사실 서술형으로 재작성 |

## 신설: 여정 타임라인 (`JourneySection`)

성장 서사를 시간순 사실로: **2026 SW마에스트로 17기 합격 → 2025 WINEQUEEN 출시 → 프로젝트 당번 → 블로그·알고리즘 연재**. 데이터는 컴포넌트 상단 배열이라 새 이력은 항목 하나 추가로 끝.

⚠️ **문구·연혁은 제가 블로그 글에서 추린 사실 기반 초안입니다** — 본인 목소리로 다듬어 주세요 (특히 타임라인 설명과 히어로 소개 문장).

## design-sync 되반영
채택 패턴을 `patterns/about-journey` 카드로 추가, Proposals 카드 삭제 (디자인 프로젝트 동기화 완료).

## 검증
- `tsc --noEmit` 통과, ESLint 에러 0
- dev 서버 실측: 새 히어로·여정 렌더링 확인, % 바 출력 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)