### PR TITLE
Feat: SEO Phase 1 — URL 정규화·페이지별 메타데이터·canonical

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,14 @@
+import { Metadata } from "next";
 import AboutMe from "@/components/AboutMe";
 import { getProjects } from "@/lib/notion/projects";
 import type { Project } from "@/lib/notion/types";
+
+export const metadata: Metadata = {
+  title: "About Me",
+  description:
+    "긍정을 전파하며 성장하는 개발자 최준서를 소개합니다 — 여정, 기술 스택, 프로젝트.",
+  alternates: { canonical: "/about" },
+};
 
 export const revalidate = 3600;
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,13 @@
+import { Metadata } from "next";
 import Blog from "@/components/Blog";
 import { getBlogPosts } from "@/lib/notion/blog";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "웹 개발, 알고리즘, 회고를 기록하는 JSChoIog의 블로그 글 목록입니다.",
+  alternates: { canonical: "/blog" },
+};
 
 // 30분마다 백그라운드 재생성 (ISR) — Notion 커버 이미지 URL 만료(약 1시간)보다
 // 짧게 유지해 깨진 이미지를 방지한다

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -29,6 +29,7 @@ export async function generateMetadata({
   return {
     title: post.title,
     description,
+    alternates: { canonical: `/blog/post/${id}` },
     openGraph: {
       title: post.title,
       description,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { SITE_URL } from "@/lib/site";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({
@@ -13,8 +14,11 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_URL || "http://localhost:3000"),
-  title: "JSChoIog",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "JSChoIog",
+    template: "%s | JSChoIog",
+  },
   description:
     "성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그입니다.",
   verification: {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
+  const baseUrl = SITE_URL;
 
   return {
     rules: {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
+  const baseUrl = SITE_URL;
 
   const staticPages: MetadataRoute.Sitemap = [
     {

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,6 @@
+// 사이트 절대 URL 단일 소스.
+// 환경변수 값 끝에 슬래시가 있어도 URL이 "//"로 이어붙지 않도록 정규화한다
+// (실서비스 sitemap이 https://…store//about 형태로 나가던 버그의 원인).
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_URL || "http://localhost:3000"
+).replace(/\/+$/, "");


### PR DESCRIPTION
> ⚠️ Stacked PR — #36(복구 PR) 머지 후 이 PR 머지. SEO 3부작의 1편.

## 변경 내용

### 🔴 버그 수정 — sitemap/robots의 `//` 이중 슬래시 URL
실서비스 sitemap이 `https://www.jschoiog.store//about` 형태로 잘못된 URL을 검색엔진에 제출하고 있었습니다. 원인은 Vercel 환경변수 `NEXT_PUBLIC_URL` 끝의 `/`. **`lib/site.ts`의 `SITE_URL`**로 단일화하고 트레일링 슬래시를 코드에서 정규화 — env 값이 어떻든 안전합니다. (Vercel env를 고칠 필요도 없어졌지만, 정리 차원에서 슬래시를 지워두면 더 좋습니다.)

로컬 검증: env에 슬래시가 있는 상태에서 sitemap URL이 `https://www.jschoiog.store/about`로 정상 출력.

### 페이지별 메타데이터
- 루트에 title template `%s | JSChoIog` — 이제 `/blog`는 "Blog | JSChoIog", 포스트는 "글제목 | JSChoIog"로 노출
- `/blog` · `/about`에 고유 title/description (기존엔 전 페이지가 "JSChoIog" 하나였음)

### canonical
포스트(`/blog/post/[id]`) · `/blog` · `/about`에 `alternates.canonical` — 중복 색인 방지의 기본값.

## 검증
`tsc`·ESLint 통과, dev 서버 실측: 이중 슬래시 0건, title template·canonical 출력 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)