### PR TITLE
Feat: SEO Phase 2 — JSON-LD·동적 OG 이미지·RSS 피드

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 import AboutMe from "@/components/AboutMe";
+import JsonLd from "@/components/JsonLd";
 import { getProjects } from "@/lib/notion/projects";
+import { SITE_URL } from "@/lib/site";
 import type { Project } from "@/lib/notion/types";
 
 export const metadata: Metadata = {
@@ -22,5 +24,22 @@ export default async function AboutPage() {
     console.error("Failed to fetch projects:", error);
   }
 
-  return <AboutMe projects={projects} />;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: "최준서",
+          url: `${SITE_URL}/about`,
+          jobTitle: "Frontend Developer",
+          sameAs: [
+            "https://github.com/evan7484",
+            "https://www.instagram.com/junseo_chl/",
+          ],
+        }}
+      />
+      <AboutMe projects={projects} />
+    </>
+  );
 }

--- a/app/blog/post/[id]/opengraph-image.tsx
+++ b/app/blog/post/[id]/opengraph-image.tsx
@@ -1,0 +1,82 @@
+import { ImageResponse } from "next/og";
+import { getBlogPostMeta } from "@/lib/notion/blog";
+
+export const revalidate = 1800;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// 한글 렌더링용 폰트 — next/og 기본 폰트에는 한글 글리프가 없다
+const FONT_URL =
+  "https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/packages/pretendard/dist/public/static/Pretendard-Bold.otf";
+
+export default async function OpengraphImage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const post = await getBlogPostMeta(id);
+  const title = post?.title || "JSChoIog";
+  const category = post?.category || "";
+
+  let fonts:
+    | { name: string; data: ArrayBuffer; weight: 700; style: "normal" }[]
+    | undefined;
+  try {
+    const data = await fetch(FONT_URL, { cache: "force-cache" }).then((r) =>
+      r.arrayBuffer()
+    );
+    fonts = [{ name: "Pretendard", data, weight: 700, style: "normal" }];
+  } catch {
+    fonts = undefined; // 폰트 로드 실패 시에도 이미지는 생성
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          padding: 80,
+          background: "linear-gradient(135deg, #f97316, #ef4444)",
+          color: "#fff",
+          fontFamily: "Pretendard",
+        }}
+      >
+        {category && (
+          <div
+            style={{
+              display: "flex",
+              fontSize: 28,
+              background: "rgba(255,255,255,.92)",
+              color: "#1f2937",
+              borderRadius: 999,
+              padding: "8px 28px",
+              marginBottom: 28,
+              alignSelf: "flex-start",
+            }}
+          >
+            {category}
+          </div>
+        )}
+        <div
+          style={{
+            fontSize: title.length > 30 ? 54 : 66,
+            fontWeight: 700,
+            lineHeight: 1.25,
+            wordBreak: "keep-all",
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ display: "flex", marginTop: 40, fontSize: 30, opacity: 0.9 }}>
+          JSChoIog
+        </div>
+      </div>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -2,7 +2,9 @@ import { cache } from "react";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import BlogPost from "@/components/BlogPost";
+import JsonLd from "@/components/JsonLd";
 import { getBlogPostById } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
 
 // Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
 export const revalidate = 1800;
@@ -55,5 +57,28 @@ export default async function BlogPostPage({ params }: PageProps) {
     notFound();
   }
 
-  return <BlogPost post={post} />;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: post.title,
+          description: post.excerpt || post.title,
+          datePublished: post.date,
+          author: {
+            "@type": "Person",
+            name: "최준서",
+            url: `${SITE_URL}/about`,
+          },
+          mainEntityOfPage: `${SITE_URL}/blog/post/${id}`,
+          ...(post.cover && { image: post.cover }),
+          keywords: post.tags.join(", "),
+          articleSection: post.category,
+          inLanguage: "ko",
+        }}
+      />
+      <BlogPost post={post} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import JsonLd from "@/components/JsonLd";
 import { SITE_URL } from "@/lib/site";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -21,6 +22,9 @@ export const metadata: Metadata = {
   },
   description:
     "성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그입니다.",
+  alternates: {
+    types: { "application/rss+xml": "/rss.xml" },
+  },
   verification: {
     other: {
       "naver-site-verification": "f3181935906491b568c387c16d9d8d13a3021534",
@@ -38,6 +42,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-linear-to-br from-orange-50 via-amber-50 to-yellow-50`}
       >
+        <JsonLd
+          data={{
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "JSChoIog",
+            url: SITE_URL,
+            inLanguage: "ko",
+          }}
+        />
         <MotionConfig reducedMotion="user">
           <Header />
           {/* pt-24: 고정 헤더(모바일 80px/데스크톱 88px)에 본문이 가리지 않도록

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,41 @@
+import { getBlogPosts } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
+
+export const revalidate = 3600;
+
+function escapeCdata(text: string): string {
+  return text.replaceAll("]]>", "]]&gt;");
+}
+
+export async function GET() {
+  const posts = await getBlogPosts();
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title><![CDATA[${escapeCdata(post.title)}]]></title>
+      <link>${SITE_URL}/blog/post/${post.id}</link>
+      <guid isPermaLink="false">${post.id}</guid>
+      ${post.date ? `<pubDate>${new Date(post.date).toUTCString()}</pubDate>` : ""}
+      <description><![CDATA[${escapeCdata(post.excerpt)}]]></description>
+      <category><![CDATA[${escapeCdata(post.category)}]]></category>
+    </item>`
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>JSChoIog</title>
+    <link>${SITE_URL}</link>
+    <description>성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그</description>
+    <language>ko</language>
+    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,9 @@
+// schema.org 구조화 데이터를 <script type="application/ld+json">으로 렌더링
+export default function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -61,7 +61,8 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
   return response.results.map((page: any) => mapPageToBlogPost(page));
 }
 
-export async function getBlogPostById(id: string): Promise<BlogPost | null> {
+// 본문 없이 메타데이터만 — OG 이미지 생성 등 가벼운 소비처용
+export async function getBlogPostMeta(id: string): Promise<BlogPost | null> {
   try {
     const page = await notion.pages.retrieve({ page_id: id });
     const post = mapPageToBlogPost(page);
@@ -69,16 +70,17 @@ export async function getBlogPostById(id: string): Promise<BlogPost | null> {
     // 미공개 글은 노출하지 않는다
     if (!post.releasable) return null;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const props = (page as any).properties;
-    post.content = await getPageContent(
-      id,
-      props.Content?.rich_text?.[0]?.plain_text || ""
-    );
-
     return post;
   } catch (error) {
     console.error("Failed to fetch blog post:", error);
     return null;
   }
+}
+
+export async function getBlogPostById(id: string): Promise<BlogPost | null> {
+  const post = await getBlogPostMeta(id);
+  if (!post) return null;
+
+  post.content = await getPageContent(id, post.excerpt);
+  return post;
 }


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #36(복구) → #37(Phase 1) → 이 PR. SEO 3부작의 2편.

## 변경 내용

### 구조화 데이터 (JSON-LD)
- **포스트**: `BlogPosting` — headline·datePublished·author(최준서)·keywords(태그)·articleSection(카테고리)·image(커버 있을 때). 구글 리치 결과(작성일·작성자 노출) 대상이 됨
- **루트**: `WebSite`, **About**: `Person`(sameAs로 GitHub·Instagram 연결)
- 공용 `components/JsonLd.tsx` 렌더러

### 동적 OG 이미지 (`opengraph-image.tsx`)
커버 없는 글도 링크 공유 시 브랜드 이미지가 나가도록 next/og로 생성 — 오렌지→레드 그라디언트 + 카테고리 칩 + 글 제목 + 워드마크. **한글 렌더링을 위해 Pretendard Bold를 로드**(next/og 기본 폰트엔 한글 글리프가 없음, 실패 시에도 이미지는 생성). 커버가 설정된 글은 generateMetadata의 명시적 `og:image`(커버)가 우선합니다.

실제 생성 이미지 (dev 서버 실측, 103KB PNG):
한글 제목 정상 렌더링 확인 완료.

### RSS 피드 (`/rss.xml`)
전체 공개 글의 RSS 2.0 피드 (ISR 1시간). CDATA 이스케이프 처리, `<atom:link rel="self">` 포함. layout에 `application/rss+xml` alternate 링크 추가. **머지 후 네이버 서치어드바이저에 RSS 제출을 권장합니다.**

### 리팩토링
`getBlogPostMeta(id)` 분리 — OG 이미지 생성이 본문 마크다운 변환(무거움) 없이 제목·카테고리만 조회.

## 검증
- `tsc`·ESLint 통과
- 실측: 포스트 페이지 JSON-LD 2건(BlogPosting+WebSite), About 2건(Person+WebSite), rss.xml 200 정상 XML, OG 이미지 200/PNG — **한글 글리프 시각 확인 완료**

🤖 Generated with [Claude Code](https://claude.com/claude-code)