### PR TITLE
Feat: SEO Phase 3 — 슬러그 URL·이미지 최적화·이전/다음 글

### DIFF
--- a/app/blog/post/[id]/opengraph-image.tsx
+++ b/app/blog/post/[id]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
-import { getBlogPostMeta } from "@/lib/notion/blog";
+import { getBlogPostMeta, getBlogPostMetaBySlug } from "@/lib/notion/blog";
+import { UUID_RE } from "@/lib/site";
 
 export const revalidate = 1800;
 export const size = { width: 1200, height: 630 };
@@ -15,7 +16,9 @@ export default async function OpengraphImage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const post = await getBlogPostMeta(id);
+  const post = UUID_RE.test(id)
+    ? await getBlogPostMeta(id)
+    : await getBlogPostMetaBySlug(id);
   const title = post?.title || "JSChoIog";
   const category = post?.category || "";
 

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -1,16 +1,23 @@
 import { cache } from "react";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import BlogPost from "@/components/BlogPost";
 import JsonLd from "@/components/JsonLd";
-import { getBlogPostById } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import {
+  getBlogPostById,
+  getBlogPostBySlug,
+  getBlogPosts,
+} from "@/lib/notion/blog";
+import { SITE_URL, UUID_RE, postPath } from "@/lib/site";
 
 // Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
 export const revalidate = 1800;
 
-// generateMetadata와 페이지 렌더링이 같은 요청을 공유하도록 캐싱
-const getPost = cache(getBlogPostById);
+// URL 파라미터는 UUID(구 URL) 또는 슬러그 — generateMetadata와 렌더링이 공유
+const resolvePost = cache(async (param: string) =>
+  UUID_RE.test(param) ? getBlogPostById(param) : getBlogPostBySlug(param)
+);
+const getPosts = cache(getBlogPosts);
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -20,7 +27,7 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const post = await getPost(id);
+  const post = await resolvePost(id);
 
   if (!post) {
     return { title: "Post Not Found" };
@@ -31,7 +38,7 @@ export async function generateMetadata({
   return {
     title: post.title,
     description,
-    alternates: { canonical: `/blog/post/${id}` },
+    alternates: { canonical: postPath(post) },
     openGraph: {
       title: post.title,
       description,
@@ -51,11 +58,22 @@ export async function generateMetadata({
 
 export default async function BlogPostPage({ params }: PageProps) {
   const { id } = await params;
-  const post = await getPost(id);
+  const post = await resolvePost(id);
 
   if (!post) {
     notFound();
   }
+
+  // 슬러그가 생긴 글의 구 UUID URL은 301로 슬러그 URL에 정착 (기존 색인 보존)
+  if (UUID_RE.test(id) && post.slug) {
+    permanentRedirect(postPath(post));
+  }
+
+  // 이전/다음 글 (목록은 날짜 내림차순)
+  const posts = await getPosts();
+  const idx = posts.findIndex((p) => p.id === post.id);
+  const newerPost = idx > 0 ? posts[idx - 1] : null;
+  const olderPost = idx >= 0 && idx < posts.length - 1 ? posts[idx + 1] : null;
 
   return (
     <>
@@ -71,14 +89,14 @@ export default async function BlogPostPage({ params }: PageProps) {
             name: "최준서",
             url: `${SITE_URL}/about`,
           },
-          mainEntityOfPage: `${SITE_URL}/blog/post/${id}`,
+          mainEntityOfPage: `${SITE_URL}${postPath(post)}`,
           ...(post.cover && { image: post.cover }),
           keywords: post.tags.join(", "),
           articleSection: post.category,
           inLanguage: "ko",
         }}
       />
-      <BlogPost post={post} />
+      <BlogPost post={post} newerPost={newerPost} olderPost={olderPost} />
     </>
   );
 }

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,5 +1,5 @@
 import { getBlogPosts } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import { SITE_URL, postPath } from "@/lib/site";
 
 export const revalidate = 3600;
 
@@ -14,7 +14,7 @@ export async function GET() {
     .map(
       (post) => `    <item>
       <title><![CDATA[${escapeCdata(post.title)}]]></title>
-      <link>${SITE_URL}/blog/post/${post.id}</link>
+      <link>${SITE_URL}${postPath(post)}</link>
       <guid isPermaLink="false">${post.id}</guid>
       ${post.date ? `<pubDate>${new Date(post.date).toUTCString()}</pubDate>` : ""}
       <description><![CDATA[${escapeCdata(post.excerpt)}]]></description>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import { SITE_URL, postPath } from "@/lib/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_URL;
@@ -30,7 +30,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const posts = await getBlogPosts();
 
     const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
-      url: `${baseUrl}/blog/post/${post.id}`,
+      url: `${baseUrl}${postPath(post)}`,
       lastModified: post.date ? new Date(post.date) : new Date(),
       changeFrequency: "weekly",
       priority: 0.8,

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
+import { postPath } from "@/lib/site";
 import type { BlogPost } from "@/lib/notion/types";
 import { CATEGORY_ICONS, DEFAULT_CATEGORY_ICON } from "@/lib/design/tokens";
 import Icon from "@/components/icons";
@@ -138,7 +140,7 @@ export default function Blog({ posts }: BlogProps) {
             {filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/post/${post.id}`}
+                href={postPath(post)}
                 className="group relative block bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all"
               >
                 <article>
@@ -148,11 +150,12 @@ export default function Blog({ posts }: BlogProps) {
                     }`}
                   >
                     {post.cover && (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
+                      <Image
                         src={post.cover}
                         alt=""
-                        className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform"
+                        fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
+                        className="object-cover group-hover:scale-105 transition-transform"
                       />
                     )}
                     <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -4,18 +4,22 @@ import { motion } from "motion/react";
 import { ArrowLeft, Check } from "lucide-react";
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import Icon from "@/components/icons";
 import Comments from "@/components/Comments";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import type { BlogPost as BlogPostType } from "@/lib/notion/types";
+import { postPath } from "@/lib/site";
 
 type Props = {
   post: BlogPostType;
+  newerPost?: BlogPostType | null;
+  olderPost?: BlogPostType | null;
 };
 
-export default function BlogPost({ post }: Props) {
+export default function BlogPost({ post, newerPost, olderPost }: Props) {
   const [isCopied, setIsCopied] = useState(false);
   const [likes, setLikes] = useState(post.likes || 0);
   const [isLiking, setIsLiking] = useState(false);
@@ -98,11 +102,13 @@ export default function BlogPost({ post }: Props) {
         transition={{ duration: 0.6 }}
       >
         {post.cover && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <Image
             src={post.cover}
             alt=""
-            className="absolute inset-0 w-full h-full object-cover"
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover"
           />
         )}
         <div className="absolute inset-0 bg-black/20" />
@@ -315,13 +321,43 @@ export default function BlogPost({ post }: Props) {
           </div>
         </div>
 
+        {/* 이전/다음 글 */}
+        {(newerPost || olderPost) && (
+          <nav className="mt-12 grid sm:grid-cols-2 gap-4">
+            {olderPost ? (
+              <Link
+                href={postPath(olderPost)}
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow"
+              >
+                <p className="text-sm text-gray-500 mb-1">← 이전 글</p>
+                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                  {olderPost.title}
+                </p>
+              </Link>
+            ) : (
+              <span />
+            )}
+            {newerPost && (
+              <Link
+                href={postPath(newerPost)}
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow text-right"
+              >
+                <p className="text-sm text-gray-500 mb-1">다음 글 →</p>
+                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                  {newerPost.title}
+                </p>
+              </Link>
+            )}
+          </nav>
+        )}
+
         {/* Comments */}
         <div className="mt-16 pt-8 border-t border-gray-200">
           <h3 className="mb-6 flex items-center gap-2 text-gray-800">
             <Icon name="chat" size={20} className="text-orange-500" />
             <span>댓글</span>
           </h3>
-          <Comments />
+          <Comments term={post.id} />
         </div>
 
         {/* Back to list */}

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -4,12 +4,13 @@ import { useEffect, useRef } from "react";
 
 // giscus (GitHub Discussions 기반 댓글) — 댓글 작성 시 GitHub 로그인은 위젯이 처리
 // repo-id/category-id는 evan7484/JSChoIog의 GraphQL node ID (Discussions 활성화 시 고정)
+// 매핑은 pathname 대신 post.id(term) — URL이 슬러그로 바뀌어도 댓글 스레드 유지
 const GISCUS_CONFIG: Record<string, string> = {
   "data-repo": "evan7484/JSChoIog",
   "data-repo-id": "R_kgDOQIPxTQ",
   "data-category": "Announcements",
   "data-category-id": "DIC_kwDOQIPxTc4DBxXx",
-  "data-mapping": "pathname",
+  "data-mapping": "specific",
   "data-strict": "0",
   "data-reactions-enabled": "1",
   "data-emit-metadata": "0",
@@ -18,7 +19,7 @@ const GISCUS_CONFIG: Record<string, string> = {
   "data-lang": "ko",
 };
 
-export default function Comments() {
+export default function Comments({ term }: { term: string }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -32,13 +33,14 @@ export default function Comments() {
     Object.entries(GISCUS_CONFIG).forEach(([key, value]) =>
       script.setAttribute(key, value)
     );
+    script.setAttribute("data-term", term);
     el.appendChild(script);
 
     // 포스트 간 이동 시 이전 위젯 정리 (pathname 매핑이 새로 잡히도록)
     return () => {
       el.innerHTML = "";
     };
-  }, []);
+  }, [term]);
 
   return <div ref={ref} className="giscus" />;
 }

--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -20,6 +20,7 @@ function mapPageToBlogPost(page: any): BlogPost {
     likes: props.Likes?.number || 0,
     // Notion 업로드 파일 URL은 만료가 있으므로(약 1시간) ISR 주기를 그보다 짧게 유지할 것
     cover: page.cover?.external?.url || page.cover?.file?.url || "",
+    slug: props.Slug?.rich_text?.[0]?.plain_text || "",
   };
 }
 
@@ -82,5 +83,37 @@ export async function getBlogPostById(id: string): Promise<BlogPost | null> {
   if (!post) return null;
 
   post.content = await getPageContent(id, post.excerpt);
+  return post;
+}
+
+// 슬러그로 조회 (본문 제외) — Notion DB에 Slug 속성이 없으면 쿼리가 400이므로 null 처리
+export async function getBlogPostMetaBySlug(
+  slug: string
+): Promise<BlogPost | null> {
+  if (!process.env.NOTION_POSTS_DATABASE_ID || !slug) return null;
+
+  try {
+    const response = await queryDatabase(process.env.NOTION_POSTS_DATABASE_ID, {
+      and: [
+        { property: "Slug", rich_text: { equals: slug } },
+        { property: "Published", checkbox: { equals: true } },
+      ],
+    });
+
+    const page = response.results[0];
+    return page ? mapPageToBlogPost(page) : null;
+  } catch (error) {
+    console.error("Failed to fetch post by slug:", error);
+    return null;
+  }
+}
+
+export async function getBlogPostBySlug(
+  slug: string
+): Promise<BlogPost | null> {
+  const post = await getBlogPostMetaBySlug(slug);
+  if (!post) return null;
+
+  post.content = await getPageContent(post.id, post.excerpt);
   return post;
 }

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -14,6 +14,8 @@ export interface BlogPost {
   likes: number;
   /** Notion 페이지 커버 이미지 URL (없으면 빈 문자열 → 그라디언트 폴백) */
   cover: string;
+  /** URL 슬러그 (Notion Slug 속성, 없으면 빈 문자열 → UUID URL 사용) */
+  slug: string;
 }
 
 export interface Project {

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,3 +4,12 @@
 export const SITE_URL = (
   process.env.NEXT_PUBLIC_URL || "http://localhost:3000"
 ).replace(/\/+$/, "");
+
+// 포스트 경로 단일 소스 — 슬러그가 있으면 슬러그, 없으면 UUID
+export function postPath(post: { id: string; slug?: string }): string {
+  return `/blog/post/${post.slug || post.id}`;
+}
+
+// Notion 페이지 ID 판별 (하이픈 유무 모두)
+export const UUID_RE =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    // 커버 이미지는 Notion CMS에서 임의 호스트(S3 서명 URL, 외부 링크)로 오므로 전체 허용
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
> ⚠️ Stacked PR — 머지 순서: #36(복구) → #37(Phase 1) → #38(Phase 2) → 이 PR. SEO 3부작의 3편.

## 변경 내용

### 슬러그 URL (`/blog/post/<slug>`)
- Notion DB에 **`Slug`(rich text) 속성을 추가하고 값을 채우면** 그 글은 슬러그 URL로 동작합니다. **속성이 없거나 비어 있으면 지금처럼 UUID URL** — 즉 머지 즉시 아무것도 깨지지 않고, 슬러그는 글별로 점진 도입 가능합니다
- 슬러그가 생긴 글의 **구 UUID URL은 301**(`permanentRedirect`)로 슬러그 URL에 정착 — 기존 검색 색인과 외부 링크 보존
- `postPath()` 헬퍼 단일 소스 — 목록 카드·sitemap·RSS·canonical·JSON-LD가 전부 같은 경로 사용
- OG 이미지 라우트도 슬러그/UUID 양쪽 해석

### 댓글 스레드 보존 (같이 필요한 변경)
giscus 매핑을 `pathname` → **`specific` + term=post.id**로 변경. URL이 슬러그로 바뀌어도 댓글 스레드가 따라옵니다. (지금 바꿔야 앞으로 쌓일 댓글이 안전)

### 이미지 최적화 (Core Web Vitals)
- 커버 이미지를 `<img>` → **`next/image`** (리사이즈·WebP 자동), 포스트 히어로는 `priority`로 LCP 최적화
- `next.config` `remotePatterns` 전체 https 허용 — 커버가 Notion S3 서명 URL/외부 링크 등 임의 호스트라서

### 내부 링크
포스트 하단 **이전/다음 글** 카드 내비게이션 — 크롤 깊이·체류시간·글 간 연결.

## Notion에서 할 일 (선택, 언제든)
1. Posts DB에 `Slug` 속성(rich text) 추가
2. 원하는 글부터 슬러그 입력 (예: `nextjs-server-components`) — 그 글만 즉시 슬러그 URL 적용

## 검증
- `tsc`·ESLint 통과, dev 실측: UUID 글 200, 미존재 슬러그 404 (Slug 속성 없는 현 상태에서도 안전), 최신 글에서 이전 글 링크만 노출(정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)