### PR TITLE
Fix: SEO Phase 1~3 전체를 main에 반영 (스택 머지 복구 2차)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next";
 import AboutMe from "@/components/AboutMe";
+import JsonLd from "@/components/JsonLd";
 import { getProjects } from "@/lib/notion/projects";
+import { SITE_URL } from "@/lib/site";
 import type { Project } from "@/lib/notion/types";
 
 export const metadata: Metadata = {
@@ -22,5 +24,22 @@ export default async function AboutPage() {
     console.error("Failed to fetch projects:", error);
   }
 
-  return <AboutMe projects={projects} />;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: "최준서",
+          url: `${SITE_URL}/about`,
+          jobTitle: "Frontend Developer",
+          sameAs: [
+            "https://github.com/evan7484",
+            "https://www.instagram.com/junseo_chl/",
+          ],
+        }}
+      />
+      <AboutMe projects={projects} />
+    </>
+  );
 }

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,14 @@
+import { Metadata } from "next";
 import AboutMe from "@/components/AboutMe";
 import { getProjects } from "@/lib/notion/projects";
 import type { Project } from "@/lib/notion/types";
+
+export const metadata: Metadata = {
+  title: "About Me",
+  description:
+    "긍정을 전파하며 성장하는 개발자 최준서를 소개합니다 — 여정, 기술 스택, 프로젝트.",
+  alternates: { canonical: "/about" },
+};
 
 export const revalidate = 3600;
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,13 @@
+import { Metadata } from "next";
 import Blog from "@/components/Blog";
 import { getBlogPosts } from "@/lib/notion/blog";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "웹 개발, 알고리즘, 회고를 기록하는 JSChoIog의 블로그 글 목록입니다.",
+  alternates: { canonical: "/blog" },
+};
 
 // 30분마다 백그라운드 재생성 (ISR) — Notion 커버 이미지 URL 만료(약 1시간)보다
 // 짧게 유지해 깨진 이미지를 방지한다

--- a/app/blog/post/[id]/opengraph-image.tsx
+++ b/app/blog/post/[id]/opengraph-image.tsx
@@ -1,0 +1,82 @@
+import { ImageResponse } from "next/og";
+import { getBlogPostMeta } from "@/lib/notion/blog";
+
+export const revalidate = 1800;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// 한글 렌더링용 폰트 — next/og 기본 폰트에는 한글 글리프가 없다
+const FONT_URL =
+  "https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/packages/pretendard/dist/public/static/Pretendard-Bold.otf";
+
+export default async function OpengraphImage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const post = await getBlogPostMeta(id);
+  const title = post?.title || "JSChoIog";
+  const category = post?.category || "";
+
+  let fonts:
+    | { name: string; data: ArrayBuffer; weight: 700; style: "normal" }[]
+    | undefined;
+  try {
+    const data = await fetch(FONT_URL, { cache: "force-cache" }).then((r) =>
+      r.arrayBuffer()
+    );
+    fonts = [{ name: "Pretendard", data, weight: 700, style: "normal" }];
+  } catch {
+    fonts = undefined; // 폰트 로드 실패 시에도 이미지는 생성
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          padding: 80,
+          background: "linear-gradient(135deg, #f97316, #ef4444)",
+          color: "#fff",
+          fontFamily: "Pretendard",
+        }}
+      >
+        {category && (
+          <div
+            style={{
+              display: "flex",
+              fontSize: 28,
+              background: "rgba(255,255,255,.92)",
+              color: "#1f2937",
+              borderRadius: 999,
+              padding: "8px 28px",
+              marginBottom: 28,
+              alignSelf: "flex-start",
+            }}
+          >
+            {category}
+          </div>
+        )}
+        <div
+          style={{
+            fontSize: title.length > 30 ? 54 : 66,
+            fontWeight: 700,
+            lineHeight: 1.25,
+            wordBreak: "keep-all",
+          }}
+        >
+          {title}
+        </div>
+        <div style={{ display: "flex", marginTop: 40, fontSize: 30, opacity: 0.9 }}>
+          JSChoIog
+        </div>
+      </div>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/app/blog/post/[id]/opengraph-image.tsx
+++ b/app/blog/post/[id]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
-import { getBlogPostMeta } from "@/lib/notion/blog";
+import { getBlogPostMeta, getBlogPostMetaBySlug } from "@/lib/notion/blog";
+import { UUID_RE } from "@/lib/site";
 
 export const revalidate = 1800;
 export const size = { width: 1200, height: 630 };
@@ -15,7 +16,9 @@ export default async function OpengraphImage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const post = await getBlogPostMeta(id);
+  const post = UUID_RE.test(id)
+    ? await getBlogPostMeta(id)
+    : await getBlogPostMetaBySlug(id);
   const title = post?.title || "JSChoIog";
   const category = post?.category || "";
 

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -1,16 +1,23 @@
 import { cache } from "react";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import BlogPost from "@/components/BlogPost";
 import JsonLd from "@/components/JsonLd";
-import { getBlogPostById } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import {
+  getBlogPostById,
+  getBlogPostBySlug,
+  getBlogPosts,
+} from "@/lib/notion/blog";
+import { SITE_URL, UUID_RE, postPath } from "@/lib/site";
 
 // Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
 export const revalidate = 1800;
 
-// generateMetadata와 페이지 렌더링이 같은 요청을 공유하도록 캐싱
-const getPost = cache(getBlogPostById);
+// URL 파라미터는 UUID(구 URL) 또는 슬러그 — generateMetadata와 렌더링이 공유
+const resolvePost = cache(async (param: string) =>
+  UUID_RE.test(param) ? getBlogPostById(param) : getBlogPostBySlug(param)
+);
+const getPosts = cache(getBlogPosts);
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -20,7 +27,7 @@ export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { id } = await params;
-  const post = await getPost(id);
+  const post = await resolvePost(id);
 
   if (!post) {
     return { title: "Post Not Found" };
@@ -31,7 +38,7 @@ export async function generateMetadata({
   return {
     title: post.title,
     description,
-    alternates: { canonical: `/blog/post/${id}` },
+    alternates: { canonical: postPath(post) },
     openGraph: {
       title: post.title,
       description,
@@ -51,11 +58,22 @@ export async function generateMetadata({
 
 export default async function BlogPostPage({ params }: PageProps) {
   const { id } = await params;
-  const post = await getPost(id);
+  const post = await resolvePost(id);
 
   if (!post) {
     notFound();
   }
+
+  // 슬러그가 생긴 글의 구 UUID URL은 301로 슬러그 URL에 정착 (기존 색인 보존)
+  if (UUID_RE.test(id) && post.slug) {
+    permanentRedirect(postPath(post));
+  }
+
+  // 이전/다음 글 (목록은 날짜 내림차순)
+  const posts = await getPosts();
+  const idx = posts.findIndex((p) => p.id === post.id);
+  const newerPost = idx > 0 ? posts[idx - 1] : null;
+  const olderPost = idx >= 0 && idx < posts.length - 1 ? posts[idx + 1] : null;
 
   return (
     <>
@@ -71,14 +89,14 @@ export default async function BlogPostPage({ params }: PageProps) {
             name: "최준서",
             url: `${SITE_URL}/about`,
           },
-          mainEntityOfPage: `${SITE_URL}/blog/post/${id}`,
+          mainEntityOfPage: `${SITE_URL}${postPath(post)}`,
           ...(post.cover && { image: post.cover }),
           keywords: post.tags.join(", "),
           articleSection: post.category,
           inLanguage: "ko",
         }}
       />
-      <BlogPost post={post} />
+      <BlogPost post={post} newerPost={newerPost} olderPost={olderPost} />
     </>
   );
 }

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -29,6 +29,7 @@ export async function generateMetadata({
   return {
     title: post.title,
     description,
+    alternates: { canonical: `/blog/post/${id}` },
     openGraph: {
       title: post.title,
       description,

--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -2,7 +2,9 @@ import { cache } from "react";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import BlogPost from "@/components/BlogPost";
+import JsonLd from "@/components/JsonLd";
 import { getBlogPostById } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
 
 // Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
 export const revalidate = 1800;
@@ -55,5 +57,28 @@ export default async function BlogPostPage({ params }: PageProps) {
     notFound();
   }
 
-  return <BlogPost post={post} />;
+  return (
+    <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: post.title,
+          description: post.excerpt || post.title,
+          datePublished: post.date,
+          author: {
+            "@type": "Person",
+            name: "최준서",
+            url: `${SITE_URL}/about`,
+          },
+          mainEntityOfPage: `${SITE_URL}/blog/post/${id}`,
+          ...(post.cover && { image: post.cover }),
+          keywords: post.tags.join(", "),
+          articleSection: post.category,
+          inLanguage: "ko",
+        }}
+      />
+      <BlogPost post={post} />
+    </>
+  );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import JsonLd from "@/components/JsonLd";
 import { SITE_URL } from "@/lib/site";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -21,6 +22,9 @@ export const metadata: Metadata = {
   },
   description:
     "성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그입니다.",
+  alternates: {
+    types: { "application/rss+xml": "/rss.xml" },
+  },
   verification: {
     other: {
       "naver-site-verification": "f3181935906491b568c387c16d9d8d13a3021534",
@@ -38,6 +42,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-linear-to-br from-orange-50 via-amber-50 to-yellow-50`}
       >
+        <JsonLd
+          data={{
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: "JSChoIog",
+            url: SITE_URL,
+            inLanguage: "ko",
+          }}
+        />
         <MotionConfig reducedMotion="user">
           <Header />
           {/* pt-24: 고정 헤더(모바일 80px/데스크톱 88px)에 본문이 가리지 않도록

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import { SITE_URL } from "@/lib/site";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({
@@ -13,8 +14,11 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_URL || "http://localhost:3000"),
-  title: "JSChoIog",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "JSChoIog",
+    template: "%s | JSChoIog",
+  },
   description:
     "성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그입니다.",
   verification: {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,8 @@
 import { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
+  const baseUrl = SITE_URL;
 
   return {
     rules: {

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,0 +1,41 @@
+import { getBlogPosts } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
+
+export const revalidate = 3600;
+
+function escapeCdata(text: string): string {
+  return text.replaceAll("]]>", "]]&gt;");
+}
+
+export async function GET() {
+  const posts = await getBlogPosts();
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title><![CDATA[${escapeCdata(post.title)}]]></title>
+      <link>${SITE_URL}/blog/post/${post.id}</link>
+      <guid isPermaLink="false">${post.id}</guid>
+      ${post.date ? `<pubDate>${new Date(post.date).toUTCString()}</pubDate>` : ""}
+      <description><![CDATA[${escapeCdata(post.excerpt)}]]></description>
+      <category><![CDATA[${escapeCdata(post.category)}]]></category>
+    </item>`
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>JSChoIog</title>
+    <link>${SITE_URL}</link>
+    <description>성실함과 열정을 바탕으로 성장하는 개발자 JSChoIog의 기술 블로그</description>
+    <language>ko</language>
+    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  });
+}

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,5 +1,5 @@
 import { getBlogPosts } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import { SITE_URL, postPath } from "@/lib/site";
 
 export const revalidate = 3600;
 
@@ -14,7 +14,7 @@ export async function GET() {
     .map(
       (post) => `    <item>
       <title><![CDATA[${escapeCdata(post.title)}]]></title>
-      <link>${SITE_URL}/blog/post/${post.id}</link>
+      <link>${SITE_URL}${postPath(post)}</link>
       <guid isPermaLink="false">${post.id}</guid>
       ${post.date ? `<pubDate>${new Date(post.date).toUTCString()}</pubDate>` : ""}
       <description><![CDATA[${escapeCdata(post.excerpt)}]]></description>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,8 +1,9 @@
 import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
+import { SITE_URL } from "@/lib/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
+  const baseUrl = SITE_URL;
 
   const staticPages: MetadataRoute.Sitemap = [
     {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
-import { SITE_URL } from "@/lib/site";
+import { SITE_URL, postPath } from "@/lib/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_URL;
@@ -30,7 +30,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const posts = await getBlogPosts();
 
     const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
-      url: `${baseUrl}/blog/post/${post.id}`,
+      url: `${baseUrl}${postPath(post)}`,
       lastModified: post.date ? new Date(post.date) : new Date(),
       changeFrequency: "weekly",
       priority: 0.8,

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
+import { postPath } from "@/lib/site";
 import type { BlogPost } from "@/lib/notion/types";
 import { CATEGORY_ICONS, DEFAULT_CATEGORY_ICON } from "@/lib/design/tokens";
 import Icon from "@/components/icons";
@@ -138,7 +140,7 @@ export default function Blog({ posts }: BlogProps) {
             {filteredPosts.map((post) => (
               <Link
                 key={post.id}
-                href={`/blog/post/${post.id}`}
+                href={postPath(post)}
                 className="group relative block bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all"
               >
                 <article>
@@ -148,11 +150,12 @@ export default function Blog({ posts }: BlogProps) {
                     }`}
                   >
                     {post.cover && (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
+                      <Image
                         src={post.cover}
                         alt=""
-                        className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform"
+                        fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
+                        className="object-cover group-hover:scale-105 transition-transform"
                       />
                     )}
                     <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -4,18 +4,22 @@ import { motion } from "motion/react";
 import { ArrowLeft, Check } from "lucide-react";
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import Icon from "@/components/icons";
 import Comments from "@/components/Comments";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import type { BlogPost as BlogPostType } from "@/lib/notion/types";
+import { postPath } from "@/lib/site";
 
 type Props = {
   post: BlogPostType;
+  newerPost?: BlogPostType | null;
+  olderPost?: BlogPostType | null;
 };
 
-export default function BlogPost({ post }: Props) {
+export default function BlogPost({ post, newerPost, olderPost }: Props) {
   const [isCopied, setIsCopied] = useState(false);
   const [likes, setLikes] = useState(post.likes || 0);
   const [isLiking, setIsLiking] = useState(false);
@@ -98,11 +102,13 @@ export default function BlogPost({ post }: Props) {
         transition={{ duration: 0.6 }}
       >
         {post.cover && (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <Image
             src={post.cover}
             alt=""
-            className="absolute inset-0 w-full h-full object-cover"
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover"
           />
         )}
         <div className="absolute inset-0 bg-black/20" />
@@ -315,13 +321,43 @@ export default function BlogPost({ post }: Props) {
           </div>
         </div>
 
+        {/* 이전/다음 글 */}
+        {(newerPost || olderPost) && (
+          <nav className="mt-12 grid sm:grid-cols-2 gap-4">
+            {olderPost ? (
+              <Link
+                href={postPath(olderPost)}
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow"
+              >
+                <p className="text-sm text-gray-500 mb-1">← 이전 글</p>
+                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                  {olderPost.title}
+                </p>
+              </Link>
+            ) : (
+              <span />
+            )}
+            {newerPost && (
+              <Link
+                href={postPath(newerPost)}
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow text-right"
+              >
+                <p className="text-sm text-gray-500 mb-1">다음 글 →</p>
+                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                  {newerPost.title}
+                </p>
+              </Link>
+            )}
+          </nav>
+        )}
+
         {/* Comments */}
         <div className="mt-16 pt-8 border-t border-gray-200">
           <h3 className="mb-6 flex items-center gap-2 text-gray-800">
             <Icon name="chat" size={20} className="text-orange-500" />
             <span>댓글</span>
           </h3>
-          <Comments />
+          <Comments term={post.id} />
         </div>
 
         {/* Back to list */}

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -4,12 +4,13 @@ import { useEffect, useRef } from "react";
 
 // giscus (GitHub Discussions 기반 댓글) — 댓글 작성 시 GitHub 로그인은 위젯이 처리
 // repo-id/category-id는 evan7484/JSChoIog의 GraphQL node ID (Discussions 활성화 시 고정)
+// 매핑은 pathname 대신 post.id(term) — URL이 슬러그로 바뀌어도 댓글 스레드 유지
 const GISCUS_CONFIG: Record<string, string> = {
   "data-repo": "evan7484/JSChoIog",
   "data-repo-id": "R_kgDOQIPxTQ",
   "data-category": "Announcements",
   "data-category-id": "DIC_kwDOQIPxTc4DBxXx",
-  "data-mapping": "pathname",
+  "data-mapping": "specific",
   "data-strict": "0",
   "data-reactions-enabled": "1",
   "data-emit-metadata": "0",
@@ -18,7 +19,7 @@ const GISCUS_CONFIG: Record<string, string> = {
   "data-lang": "ko",
 };
 
-export default function Comments() {
+export default function Comments({ term }: { term: string }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -32,13 +33,14 @@ export default function Comments() {
     Object.entries(GISCUS_CONFIG).forEach(([key, value]) =>
       script.setAttribute(key, value)
     );
+    script.setAttribute("data-term", term);
     el.appendChild(script);
 
     // 포스트 간 이동 시 이전 위젯 정리 (pathname 매핑이 새로 잡히도록)
     return () => {
       el.innerHTML = "";
     };
-  }, []);
+  }, [term]);
 
   return <div ref={ref} className="giscus" />;
 }

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -1,0 +1,9 @@
+// schema.org 구조화 데이터를 <script type="application/ld+json">으로 렌더링
+export default function JsonLd({ data }: { data: object }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -20,6 +20,7 @@ function mapPageToBlogPost(page: any): BlogPost {
     likes: props.Likes?.number || 0,
     // Notion 업로드 파일 URL은 만료가 있으므로(약 1시간) ISR 주기를 그보다 짧게 유지할 것
     cover: page.cover?.external?.url || page.cover?.file?.url || "",
+    slug: props.Slug?.rich_text?.[0]?.plain_text || "",
   };
 }
 
@@ -82,5 +83,37 @@ export async function getBlogPostById(id: string): Promise<BlogPost | null> {
   if (!post) return null;
 
   post.content = await getPageContent(id, post.excerpt);
+  return post;
+}
+
+// 슬러그로 조회 (본문 제외) — Notion DB에 Slug 속성이 없으면 쿼리가 400이므로 null 처리
+export async function getBlogPostMetaBySlug(
+  slug: string
+): Promise<BlogPost | null> {
+  if (!process.env.NOTION_POSTS_DATABASE_ID || !slug) return null;
+
+  try {
+    const response = await queryDatabase(process.env.NOTION_POSTS_DATABASE_ID, {
+      and: [
+        { property: "Slug", rich_text: { equals: slug } },
+        { property: "Published", checkbox: { equals: true } },
+      ],
+    });
+
+    const page = response.results[0];
+    return page ? mapPageToBlogPost(page) : null;
+  } catch (error) {
+    console.error("Failed to fetch post by slug:", error);
+    return null;
+  }
+}
+
+export async function getBlogPostBySlug(
+  slug: string
+): Promise<BlogPost | null> {
+  const post = await getBlogPostMetaBySlug(slug);
+  if (!post) return null;
+
+  post.content = await getPageContent(post.id, post.excerpt);
   return post;
 }

--- a/lib/notion/blog.ts
+++ b/lib/notion/blog.ts
@@ -61,7 +61,8 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
   return response.results.map((page: any) => mapPageToBlogPost(page));
 }
 
-export async function getBlogPostById(id: string): Promise<BlogPost | null> {
+// 본문 없이 메타데이터만 — OG 이미지 생성 등 가벼운 소비처용
+export async function getBlogPostMeta(id: string): Promise<BlogPost | null> {
   try {
     const page = await notion.pages.retrieve({ page_id: id });
     const post = mapPageToBlogPost(page);
@@ -69,16 +70,17 @@ export async function getBlogPostById(id: string): Promise<BlogPost | null> {
     // 미공개 글은 노출하지 않는다
     if (!post.releasable) return null;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const props = (page as any).properties;
-    post.content = await getPageContent(
-      id,
-      props.Content?.rich_text?.[0]?.plain_text || ""
-    );
-
     return post;
   } catch (error) {
     console.error("Failed to fetch blog post:", error);
     return null;
   }
+}
+
+export async function getBlogPostById(id: string): Promise<BlogPost | null> {
+  const post = await getBlogPostMeta(id);
+  if (!post) return null;
+
+  post.content = await getPageContent(id, post.excerpt);
+  return post;
 }

--- a/lib/notion/types.ts
+++ b/lib/notion/types.ts
@@ -14,6 +14,8 @@ export interface BlogPost {
   likes: number;
   /** Notion 페이지 커버 이미지 URL (없으면 빈 문자열 → 그라디언트 폴백) */
   cover: string;
+  /** URL 슬러그 (Notion Slug 속성, 없으면 빈 문자열 → UUID URL 사용) */
+  slug: string;
 }
 
 export interface Project {

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -4,3 +4,12 @@
 export const SITE_URL = (
   process.env.NEXT_PUBLIC_URL || "http://localhost:3000"
 ).replace(/\/+$/, "");
+
+// 포스트 경로 단일 소스 — 슬러그가 있으면 슬러그, 없으면 UUID
+export function postPath(post: { id: string; slug?: string }): string {
+  return `/blog/post/${post.slug || post.id}`;
+}
+
+// Notion 페이지 ID 판별 (하이픈 유무 모두)
+export const UUID_RE =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,6 @@
+// 사이트 절대 URL 단일 소스.
+// 환경변수 값 끝에 슬래시가 있어도 URL이 "//"로 이어붙지 않도록 정규화한다
+// (실서비스 sitemap이 https://…store//about 형태로 나가던 버그의 원인).
+export const SITE_URL = (
+  process.env.NEXT_PUBLIC_URL || "http://localhost:3000"
+).replace(/\/+$/, "");

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    // 커버 이미지는 Notion CMS에서 임의 호스트(S3 서명 URL, 외부 링크)로 오므로 전체 허용
+    remotePatterns: [{ protocol: "https", hostname: "**" }],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 상황

#37/#38/#39가 또 각자의 base 피처 브랜치로 머지됐습니다 (브랜치를 삭제하지 않으면 GitHub가 다음 PR의 base를 main으로 올려주지 않습니다):
- #37 → design/about-redesign
- #38 → seo/phase-1-metadata
- #39 → seo/phase-2-discovery ← **이 브랜치에 Phase 1~3 전부 누적**

이 PR 하나로 SEO 3부작 전체가 main에 반영됩니다. `next.config`의 remotePatterns, `lib/site.ts`의 postPath 등 Phase 3 변경까지 포함된 것을 확인했습니다.

## ✅ 앞으로 스택 머지할 때
**머지 직후 "Delete branch" 버튼을 꼭 누르세요.** 그래야 그 브랜치를 base로 쓰던 다음 PR이 자동으로 main을 바라봅니다. (또는 `gh pr merge N --merge --delete-branch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)