### PR TITLE
Fix: sitemap ISR 재생성 추가 (1시간)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,10 @@ import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
 import { SITE_URL, postPath } from "@/lib/site";
 
+// 빌드 시점 캐시로 고정되지 않도록 1시간마다 재생성
+// (슬러그 도입처럼 URL이 바뀌어도 재배포 없이 sitemap이 따라오게)
+export const revalidate = 3600;
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_URL;
 


### PR DESCRIPTION
슬러그 47개를 Notion에 입력한 뒤 확인해보니, 포스트 페이지는 슬러그 URL·301이 즉시 동작하는데 **sitemap만 빌드 시점 캐시로 고정**되어 구 UUID URL을 계속 내보내고 있었습니다. `revalidate = 3600` 한 줄로 1시간마다 재생성되게 수정 — 앞으로 글 추가/URL 변경 시 재배포 없이 sitemap이 따라옵니다.

base가 main인 단독 PR이라 그냥 머지하시면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)