### PR TITLE
Feat: GA4 연동 — 페이지뷰 추적

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { MotionConfig } from "motion/react";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import "./globals.css";
 
 import Header from "@/components/Header";
@@ -58,6 +59,10 @@ export default function RootLayout({
           <main className="pt-24 overflow-x-clip">{children}</main>
           <Footer />
         </MotionConfig>
+        {/* GA4 — 측정 ID가 설정된 환경(프로덕션)에서만 로드 */}
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+        )}
       </body>
     </html>
   );

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,6 +2,10 @@ import { MetadataRoute } from "next";
 import { getBlogPosts } from "@/lib/notion/blog";
 import { SITE_URL, postPath } from "@/lib/site";
 
+// 빌드 시점 캐시로 고정되지 않도록 1시간마다 재생성
+// (슬러그 도입처럼 URL이 바뀌어도 재배포 없이 sitemap이 따라오게)
+export const revalidate = 3600;
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SITE_URL;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jschoilog",
       "version": "0.1.0",
       "dependencies": {
+        "@next/third-parties": "^16.2.11",
         "@notionhq/client": "^5.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1148,6 +1149,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.2.11",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.11.tgz",
+      "integrity": "sha512-w/e7lmAj7UzolcGH8Hn8TlX1/a9xZUJLUhvvIO6PNZhYLymPT4xeu5LsMn+RocD+0uRNhHl4GoRAhCgZrt3hjw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7679,6 +7693,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@next/third-parties": "^16.2.11",
     "@notionhq/client": "^5.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## 요약

GA4를 공식 `@next/third-parties/google`의 `<GoogleAnalytics>`로 연동. App Router의 클라이언트 라우트 전환까지 페이지뷰가 자동 추적됩니다.

- `NEXT_PUBLIC_GA_ID` **환경변수가 있을 때만 로드** — 로컬 dev나 ID 미설정 환경에서는 스크립트 자체가 안 들어가 데이터 오염 없음
- 검증: 더미 ID 주입 시 `gtag/js?id=…` 로드 확인, 제거 시 미로드 확인

## ⚠️ 머지 전/후 필요한 설정 (계정 필요)

1. [analytics.google.com](https://analytics.google.com) → 관리(⚙️) → **속성 만들기** → 플랫폼 "웹" 데이터 스트림 생성 (URL: `https://www.jschoiog.store`)
2. 발급된 **측정 ID (`G-XXXXXXXXXX`)** 복사
3. Vercel → 프로젝트 Settings → Environment Variables에 `NEXT_PUBLIC_GA_ID` = 측정 ID (Production) 추가 → 재배포

이후 GA4의 **실시간** 보고서에서 즉시, **참여도 → 페이지 및 화면**에서 페이지별 조회수를 볼 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)