### PR TITLE
Feat: 검색 스니펫 개선 — 본문 기반 description + nosnippet

### DIFF
--- a/app/blog/post/[id]/page.tsx
+++ b/app/blog/post/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   getBlogPosts,
 } from "@/lib/notion/blog";
 import { SITE_URL, UUID_RE, postPath } from "@/lib/site";
+import { postDescription } from "@/lib/text";
 
 // Notion 커버 이미지 URL 만료(약 1시간)보다 짧게
 export const revalidate = 1800;
@@ -33,7 +34,7 @@ export async function generateMetadata({
     return { title: "Post Not Found" };
   }
 
-  const description = post.excerpt || post.title;
+  const description = postDescription(post);
 
   return {
     title: post.title,
@@ -82,7 +83,7 @@ export default async function BlogPostPage({ params }: PageProps) {
           "@context": "https://schema.org",
           "@type": "BlogPosting",
           headline: post.title,
-          description: post.excerpt || post.title,
+          description: postDescription(post),
           datePublished: post.date,
           author: {
             "@type": "Person",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,7 +16,11 @@ const socialLinks = [
 
 export default function Footer() {
   return (
-    <footer className="mt-20 bg-linear-to-r from-orange-100 to-amber-100 py-12">
+    // data-nosnippet: 검색엔진이 푸터 텍스트를 스니펫으로 쓰지 못하게
+    <footer
+      data-nosnippet=""
+      className="mt-20 bg-linear-to-r from-orange-100 to-amber-100 py-12"
+    >
       <div className="max-w-7xl mx-auto px-6 text-center">
         <p className="text-gray-700">
           © {new Date().getFullYear()} JSChoIog. Built with passion and

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,11 @@ export default function Header() {
   const isAbout = pathname === "/about" || pathname.startsWith("/about/");
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-orange-100">
+    // data-nosnippet: 검색엔진이 헤더 텍스트를 스니펫으로 쓰지 못하게
+    <header
+      data-nosnippet=""
+      className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-orange-100"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
         <Link
           href="/blog"

--- a/lib/text.ts
+++ b/lib/text.ts
@@ -1,0 +1,32 @@
+// 마크다운을 평문으로 변환 (검색 스니펫·meta description 생성용)
+export function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ") // 코드 블록
+    .replace(/`[^`]*`/g, " ") // 인라인 코드
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // 이미지
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // 링크 → 텍스트만
+    .replace(/<[^>]+>/g, " ") // HTML 태그
+    .replace(/^#{1,6}\s+/gm, "") // 헤딩 마커
+    .replace(/^[-*+]\s+/gm, "") // 리스트 마커
+    .replace(/^>\s*/gm, "") // 인용 마커
+    .replace(/[*_~]{1,3}/g, "") // 강조
+    .replace(/\|/g, " ") // 표 구분자
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// 검색 결과에 나갈 글 설명 — 작성한 excerpt가 충분하면 그대로,
+// 없거나 너무 짧으면("독후감", "내 썰" 등) 본문 앞부분을 미리보기로 사용
+export function postDescription(post: {
+  title: string;
+  excerpt: string;
+  content?: string;
+}): string {
+  const excerpt = post.excerpt.trim();
+  if (excerpt.length >= 20) return excerpt;
+
+  const plain = markdownToPlainText(post.content || "");
+  if (!plain) return excerpt || post.title;
+
+  return plain.length > 155 ? plain.slice(0, 155).trimEnd() + "…" : plain;
+}


### PR DESCRIPTION
## 문제

구글 검색 결과에서 글 스니펫이 본문 미리보기가 아니라 "JSChoIog! BlogAbout Me © 2025 … Instagram LinkedIn GitHub" 같은 헤더·푸터 텍스트로 나옴.

**원인 2가지:**
1. 해당 스니펫은 서버 렌더링 전환(#26) **이전** 크롤 결과 — 당시 크롤러가 본 텍스트는 헤더·푸터뿐이었음
2. 글의 meta description이 `"독후감"`, `"내 썰"` 같은 초단문 excerpt라 구글이 무시하고 페이지 텍스트를 직접 조합

## 수정

### 본문 기반 description 자동 생성 (`lib/text.ts`)
- excerpt가 **20자 이상이면 그대로 사용** (직접 쓴 요약 존중)
- 없거나 짧으면 **본문 앞 155자**를 마크다운 → 평문 변환해 사용 (코드블록·이미지·링크·마커 제거)
- meta description + og/twitter description + JSON-LD description 모두 동일 적용

실측 (dev): `"독후감"` → `"인스타 스토리를 보고 … 시간이랑 의지가…"` (실제 본문 미리보기)

### `data-nosnippet` (헤더·푸터)
구글 공식 속성 — 이 영역 텍스트를 스니펫에 사용하지 못하게 명시. 재크롤 후에는 어떤 경우에도 보일러플레이트 스니펫이 나오지 않음.

## 반영 시점 안내
스니펫은 **구글이 재크롤해야** 바뀝니다. Search Console → URL 검사 → "색인 생성 요청"으로 주요 글 몇 개를 수동 재요청하면 며칠 내로 갱신됩니다 (안 해도 자연 재크롤로 갱신, 다만 느림).

🤖 Generated with [Claude Code](https://claude.com/claude-code)