### PR TITLE
Feat: 코드 블록 문법 하이라이팅 + 복사 버튼

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,15 @@
 @import "tailwindcss";
+/* 코드 블록 문법 하이라이팅 (rehype-highlight) */
+@import "highlight.js/styles/github-dark.css";
 
 @custom-variant dark (&:is(.dark *));
+
+/* 컨테이너(CodeBlock의 pre)가 배경·패딩을 담당하므로 hljs 자체 배경은 제거,
+   토큰 색상만 gray-900 위에 얹는다 */
+.hljs {
+  background: transparent;
+  padding: 0;
+}
 
 :root {
   --font-size: 16px;

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -7,8 +7,10 @@ import Link from "next/link";
 import Image from "next/image";
 import Icon from "@/components/icons";
 import Comments from "@/components/Comments";
+import CodeBlock from "@/components/CodeBlock";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
+import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 import type { BlogPost as BlogPostType } from "@/lib/notion/types";
 import { postPath } from "@/lib/site";
@@ -160,7 +162,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
         <div className="max-w-none">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
+            rehypePlugins={[rehypeRaw, rehypeHighlight]}
             components={{
               h1: ({ ...props }) => (
                 <h1
@@ -219,19 +221,12 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
                     {children}
                   </code>
                 ) : (
-                  <code
-                    className="block bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto font-mono text-sm"
-                    {...props}
-                  >
+                  // 블록 코드는 className(hljs·language-*)을 보존해 하이라이팅 유지
+                  <code className={className} {...props}>
                     {children}
                   </code>
                 ),
-              pre: ({ ...props }) => (
-                <pre
-                  className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto my-6"
-                  {...props}
-                />
-              ),
+              pre: (props) => <CodeBlock {...props} />,
               a: ({ ...props }) => (
                 <a
                   className="text-orange-500 hover:text-orange-600 underline"

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+// 마크다운 코드 블록 래퍼 — 복사 버튼 제공.
+// 문법 하이라이팅은 rehype-highlight가 내부 <code>에 입힌다.
+export default function CodeBlock({
+  children,
+  // react-markdown이 넘기는 node는 DOM에 전달하지 않는다
+  node: _node,
+  ...props
+}: React.HTMLAttributes<HTMLPreElement> & { node?: unknown }) {
+  const ref = useRef<HTMLPreElement>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = ref.current?.innerText ?? "";
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy code:", err);
+    }
+  };
+
+  return (
+    <div className="relative group/code my-6">
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "복사됨" : "코드 복사"}
+        className="absolute right-3 top-3 z-10 inline-flex items-center gap-1 rounded-md bg-white/10 px-2.5 py-1.5 text-xs text-gray-300 backdrop-blur-sm transition-all hover:bg-white/20 opacity-0 group-hover/code:opacity-100 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400"
+      >
+        {copied ? (
+          <>
+            <Check className="w-3.5 h-3.5 text-green-400" />
+            <span>복사됨</span>
+          </>
+        ) : (
+          <>
+            <Copy className="w-3.5 h-3.5" />
+            <span>복사</span>
+          </>
+        )}
+      </button>
+      <pre
+        ref={ref}
+        className="bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm"
+        {...props}
+      >
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@notionhq/client": "^5.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "highlight.js": "^11.11.1",
         "lucide-react": "^0.553.0",
         "motion": "^12.23.24",
         "next": "^16.0.7",
@@ -19,6 +20,7 @@
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-markdown": "^10.1.0",
+        "rehype-highlight": "^7.0.2",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0"
@@ -4159,6 +4161,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -4243,6 +4258,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4288,6 +4319,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/html-url-attributes": {
@@ -5313,6 +5353,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -6965,6 +7020,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
@@ -8000,6 +8072,20 @@
         "is-plain-obj": "^4.0.0",
         "trough": "^2.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@notionhq/client": "^5.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "highlight.js": "^11.11.1",
     "lucide-react": "^0.553.0",
     "motion": "^12.23.24",
     "next": "^16.0.7",
@@ -20,6 +21,7 @@
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-markdown": "^10.1.0",
+    "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0"


### PR DESCRIPTION
## 요약

UI/UX 개선 4종 중 **1/4 — 코드 블록 UX**. 백준 Python·JS 글이 많은 테크 블로그인데 코드가 평문 회색 박스였던 것을 개선.

## 변경 내용

### 문법 하이라이팅
- `rehype-highlight` 플러그인 추가 (`rehypePlugins: [rehypeRaw, rehypeHighlight]`)
- `highlight.js/styles/github-dark.css` 테마 임포트, `.hljs` 배경만 투명 처리해 **기존 gray-900 컨테이너 위에 토큰 색상만** 얹음 (디자인 일관성 유지)
- 블록 `code` 렌더러가 `hljs`·`language-*` 클래스를 보존하도록 수정 (기존엔 className을 덮어써서 하이라이팅이 불가능했음)

### 복사 버튼 (`components/CodeBlock.tsx`)
- 코드 블록 hover 또는 키보드 포커스 시 우상단에 복사 버튼 표시
- `navigator.clipboard`로 복사 + "복사됨" 피드백(2초)
- `focus-visible` 아웃라인 포함 (버튼 자체 접근성)

## 검증
- `tsc`·ESLint 통과
- dev 실측 (`boj-2606-virus` 글): `language-python` 감지 → hljs 토큰(keyword/built_in/number) 하이라이팅 확인, 복사 버튼 렌더링 확인

## 다음 (별도 PR, 이 PR 머지 후 순차 진행)
2/4 접근성+상태화면 · 3/4 성능+모바일 · 4/4 다크모드. 파일 충돌 방지를 위해 다크모드(전 컴포넌트 영향)를 마지막에 진행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)