### PR TITLE
Feat: 접근성 focus 링 + 로딩/에러/404 상태 화면

### DIFF
--- a/app/about/loading.tsx
+++ b/app/about/loading.tsx
@@ -1,0 +1,9 @@
+// /about 로딩 — 정적 페이지라 짧게 지나가므로 간단한 스피너
+export default function AboutLoading() {
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-24 flex flex-col items-center justify-center">
+      <div className="h-10 w-10 rounded-full border-4 border-orange-200 border-t-orange-500 animate-spin" />
+      <p className="mt-4 text-gray-500">불러오는 중…</p>
+    </div>
+  );
+}

--- a/app/blog/loading.tsx
+++ b/app/blog/loading.tsx
@@ -1,0 +1,31 @@
+// /blog 로딩 스켈레톤 — 목록 그리드 형태를 미리 잡아 레이아웃 시프트 방지
+export default function BlogLoading() {
+  return (
+    <div className="max-w-7xl mx-auto px-6 py-12">
+      <div className="flex flex-col lg:flex-row gap-8">
+        <aside className="lg:w-64 shrink-0">
+          <div className="bg-white rounded-2xl shadow-lg p-6 h-64 animate-pulse" />
+        </aside>
+        <div className="flex-1">
+          <div className="h-8 w-40 bg-gray-200 rounded-lg mb-8 animate-pulse" />
+          <div className="h-12 w-full bg-white rounded-full shadow-md mb-8 animate-pulse" />
+          <div className="grid md:grid-cols-2 gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="bg-white rounded-2xl overflow-hidden shadow-lg animate-pulse"
+              >
+                <div className="h-48 bg-gray-200" />
+                <div className="p-6 space-y-3">
+                  <div className="h-4 w-24 bg-gray-200 rounded-full" />
+                  <div className="h-5 w-3/4 bg-gray-200 rounded" />
+                  <div className="h-4 w-full bg-gray-100 rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/blog/post/[id]/loading.tsx
+++ b/app/blog/post/[id]/loading.tsx
@@ -1,0 +1,26 @@
+// 포스트 상세 로딩 스켈레톤 — 히어로 + 본문 라인
+export default function PostLoading() {
+  return (
+    <div className="min-h-screen">
+      <div className="max-w-4xl mx-auto px-6 py-6">
+        <div className="h-6 w-32 bg-gray-200 rounded animate-pulse" />
+      </div>
+      <div className="h-80 bg-gray-200 mb-12 animate-pulse" />
+      <div className="max-w-4xl mx-auto px-6 pb-20">
+        <div className="flex gap-2 mb-12 pb-8 border-b border-gray-200">
+          <div className="h-9 w-20 bg-gray-100 rounded-full animate-pulse" />
+          <div className="h-9 w-24 bg-gray-100 rounded-full animate-pulse" />
+        </div>
+        <div className="space-y-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-4 bg-gray-100 rounded animate-pulse"
+              style={{ width: `${[100, 92, 96, 70, 88, 100, 60, 84][i]}%` }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+
+// 전역 에러 바운더리 — 렌더/데이터 오류 시 기본 Next 화면 대신 노출
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Page error:", error);
+  }, [error]);
+
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-24 text-center">
+      <span className="text-6xl mb-4 block">🌩️</span>
+      <h1 className="mb-3 text-gray-900">문제가 발생했어요</h1>
+      <p className="text-gray-600 mb-8 break-keep">
+        페이지를 불러오는 중 오류가 났습니다. 잠시 후 다시 시도해 주세요.
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="inline-flex items-center gap-2 px-8 py-3 bg-linear-to-r from-orange-500 to-red-500 text-white rounded-full hover:shadow-lg hover:scale-105 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+// 전역 404 — 포스트 notFound() 및 없는 경로 접근 시
+export default function NotFound() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-24 text-center">
+      <p className="text-7xl font-bold bg-linear-to-r from-orange-500 to-red-500 bg-clip-text text-transparent">
+        404
+      </p>
+      <h1 className="mt-4 mb-3 text-gray-900">페이지를 찾을 수 없어요</h1>
+      <p className="text-gray-600 mb-8 break-keep">
+        주소가 바뀌었거나 삭제된 글일 수 있습니다. 목록에서 다시 찾아보세요.
+      </p>
+      <Link
+        href="/blog"
+        className="inline-flex items-center gap-2 px-8 py-3 bg-linear-to-r from-orange-500 to-red-500 text-white rounded-full hover:shadow-lg hover:scale-105 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+      >
+        블로그 목록으로
+      </Link>
+    </div>
+  );
+}

--- a/components/AboutMe/ProjectModal.tsx
+++ b/components/AboutMe/ProjectModal.tsx
@@ -48,6 +48,9 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${project.title} 프로젝트`}
         className="bg-white rounded-3xl max-w-3xl w-full shadow-2xl overflow-hidden my-auto"
         onClick={(e) => e.stopPropagation()}
       >
@@ -58,7 +61,8 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
           <div className="absolute inset-0 bg-black/20" />
           <button
             onClick={onClose}
-            className="absolute top-6 right-6 w-12 h-12 rounded-full bg-white/90 hover:bg-white flex items-center justify-center transition-colors shadow-lg z-10"
+            aria-label="닫기"
+            className="absolute top-6 right-6 w-12 h-12 rounded-full bg-white/90 hover:bg-white flex items-center justify-center transition-colors shadow-lg z-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           >
             <X className="w-5 h-5 text-gray-700" />
           </button>

--- a/components/AboutMe/ProjectsSection.tsx
+++ b/components/AboutMe/ProjectsSection.tsx
@@ -18,9 +18,11 @@ export default function ProjectsSection({
       </h3>
       <div className="grid md:grid-cols-3 gap-6">
         {projects.map((project) => (
-          <div
+          <button
             key={project.id}
-            className="group relative bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all cursor-pointer"
+            type="button"
+            aria-label={`${project.title} 프로젝트 자세히 보기`}
+            className="group relative block w-full text-left bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
             onClick={() => onProjectSelect(String(project.id))}
           >
             <div
@@ -54,7 +56,7 @@ export default function ProjectsSection({
               </div>
             </div>
             <div className="absolute inset-0 border-2 border-orange-400 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
-          </div>
+          </button>
         ))}
       </div>
     </div>

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -76,7 +76,7 @@ export default function Blog({ posts }: BlogProps) {
                 <button
                   key={category.name}
                   onClick={() => setSelectedCategory(category.name)}
-                  className={`w-full flex items-center justify-between px-4 py-3 rounded-xl transition-all hover:scale-105 active:scale-95 ${
+                  className={`w-full flex items-center justify-between px-4 py-3 rounded-xl transition-all hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                     selectedCategory === category.name
                       ? "bg-linear-to-r from-orange-400 to-red-400 text-white shadow-lg"
                       : "bg-gray-50 text-gray-700 hover:bg-orange-50"
@@ -141,7 +141,7 @@ export default function Blog({ posts }: BlogProps) {
               <Link
                 key={post.id}
                 href={postPath(post)}
-                className="group relative block bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all"
+                className="group relative block bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               >
                 <article>
                   <div

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -87,7 +87,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
       <div className="max-w-4xl mx-auto px-6 py-6">
         <Link
           href="/blog"
-          className="inline-flex items-center gap-2 text-gray-700 hover:text-orange-600 hover:-translate-x-1 transition-all"
+          className="inline-flex items-center gap-2 text-gray-700 hover:text-orange-600 hover:-translate-x-1 transition-all rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
         >
           <ArrowLeft className="w-5 h-5" />
           <span>목록으로 돌아가기</span>
@@ -276,7 +276,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
               <motion.button
                 onClick={handleLike}
                 disabled={isLiking}
-                className={`px-6 py-2 rounded-full transition-colors ${
+                className={`px-6 py-2 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                   hasLiked
                     ? "bg-orange-200 text-orange-700 hover:bg-orange-300"
                     : "bg-orange-100 text-orange-600 hover:bg-orange-200"
@@ -296,7 +296,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
               </motion.button>
               <motion.button
                 onClick={handleShare}
-                className="px-6 py-2 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-200 transition-colors"
+                className="px-6 py-2 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -322,7 +322,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
             {olderPost ? (
               <Link
                 href={postPath(olderPost)}
-                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow"
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               >
                 <p className="text-sm text-gray-500 mb-1">← 이전 글</p>
                 <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
@@ -335,7 +335,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
             {newerPost && (
               <Link
                 href={postPath(newerPost)}
-                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow text-right"
+                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 text-right"
               >
                 <p className="text-sm text-gray-500 mb-1">다음 글 →</p>
                 <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
@@ -359,7 +359,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
         <div className="mt-12 text-center">
           <Link
             href="/blog"
-            className="inline-flex items-center gap-2 px-8 py-3 bg-linear-to-r from-orange-500 to-red-500 text-white rounded-full hover:shadow-lg hover:scale-105 active:scale-95 transition-all"
+            className="inline-flex items-center gap-2 px-8 py-3 bg-linear-to-r from-orange-500 to-red-500 text-white rounded-full hover:shadow-lg hover:scale-105 active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
           >
             <ArrowLeft className="w-5 h-5" />
             <span>다른 글 보러가기</span>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -33,7 +33,7 @@ export default function Footer() {
               href={link.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="relative w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all group"
+              className="relative w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all group focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               title={link.label}
             >
               <Icon name={link.icon} size={18} className="text-orange-600" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
         <Link
           href="/blog"
-          className="flex items-center gap-2 sm:gap-3 cursor-pointer hover:opacity-80 transition-opacity min-w-0"
+          className="flex items-center gap-2 sm:gap-3 cursor-pointer hover:opacity-80 transition-opacity min-w-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
         >
           <div className="w-12 h-12 sm:w-14 sm:h-14 shrink-0 bg-linear-to-br from-orange-400 to-red-100 rounded-full flex items-center justify-center shadow-lg">
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -54,7 +54,7 @@ function NavLink({
   return (
     <Link
       href={href}
-      className={`px-4 sm:px-6 py-2 rounded-full transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center whitespace-nowrap ${
+      className={`px-4 sm:px-6 py-2 rounded-full transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
         active
           ? "bg-linear-to-r from-orange-500 to-red-500 text-white shadow-lg"
           : "text-gray-700 hover:bg-orange-50"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 요약

UI/UX 개선 **2/4 — 접근성 + 상태 화면**. main 기반 독립 PR.

## 변경 내용

### 키보드 접근성 (focus-visible)
기존엔 컴포넌트 전체에서 focus-visible이 검색창 1곳뿐이라 키보드 사용자가 포커스 위치를 알 수 없었음. 모든 상호작용 요소에 `focus-visible:ring-2 ring-orange-400 ring-offset-2` 통일:
- 헤더 로고·네비 필, 블로그 카드·카테고리 버튼, 좋아요/공유/뒤로가기, 이전·다음 글, 푸터 소셜, 모달 닫기
- **프로젝트 카드를 `div[onClick]` → `<button>`으로 변환** (기존엔 키보드로 아예 열 수 없었음) + aria-label
- 프로젝트 모달에 `role="dialog"` / `aria-modal` / `aria-label`

### 상태 화면 (App Router 특수 파일)
- `app/blog/loading.tsx` — 목록 스켈레톤(그리드 형태로 레이아웃 시프트 방지)
- `app/blog/post/[id]/loading.tsx` — 히어로+본문 스켈레톤
- `app/about/loading.tsx` — 스피너
- `app/not-found.tsx` — 브랜드 404 (목록으로 링크)
- `app/error.tsx` — 에러 바운더리 (다시 시도 버튼)

## 검증
- `tsc`·ESLint 통과, **프로덕션 빌드 성공**
- focus 링 8개 파일 적용 확인, 404 UI 렌더링 확인

## ⚠️ 별도 발견 (이 PR 범위 아님)
not-found UI를 붙이며 확인해보니, **없는 슬러그가 HTTP 200(soft 404)로 응답**합니다 (프로덕션 빌드로도 재현). `notFound()` + `revalidate`(ISR) 조합의 Next.js 알려진 이슈로, Phase 3(슬러그) 때부터 있던 기존 문제이며 이 PR이 만든 게 아닙니다. SEO상 soft 404는 바람직하지 않아 별도로 조사/수정 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)