### PR TITLE
Feat: 본문 이미지 next/image + 모바일 카테고리 가로 칩

### DIFF
--- a/components/AboutMe/ProjectModal.tsx
+++ b/components/AboutMe/ProjectModal.tsx
@@ -3,6 +3,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { useEffect, useMemo } from "react";
 import { X } from "lucide-react";
+import Image from "next/image";
 import type { Project } from "@/lib/notion/types";
 import Icon from "@/components/icons";
 
@@ -169,9 +170,18 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
                   {...props}
                 />
               ),
-              img: ({ node, ...props }) => (
-                <img className="rounded-lg my-4 w-full" {...props} />
-              ),
+              img: ({ src, alt }) =>
+                typeof src === "string" ? (
+                  <Image
+                    src={src}
+                    alt={alt || ""}
+                    width={0}
+                    height={0}
+                    sizes="(max-width: 768px) 100vw, 700px"
+                    className="rounded-lg my-4"
+                    style={{ width: "100%", height: "auto" }}
+                  />
+                ) : null,
             }}
           >
             {memoizedContent}

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -64,8 +64,8 @@ export default function Blog({ posts }: BlogProps) {
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
       <div className="flex flex-col lg:flex-row gap-8">
-        {/* Sidebar */}
-        <aside className="lg:w-64 shrink-0">
+        {/* Sidebar (데스크톱) */}
+        <aside className="hidden lg:block lg:w-64 shrink-0">
           <div className="bg-white rounded-2xl shadow-lg p-6 lg:sticky lg:top-28">
             <h3 className="mb-6 flex items-center gap-2">
               <Icon name="book" size={22} className="text-orange-500" />
@@ -110,7 +110,43 @@ export default function Blog({ posts }: BlogProps) {
         </aside>
 
         {/* Main Content */}
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
+          {/* 카테고리 (모바일) — 가로 스크롤 칩. 세로 사이드바가 목록을
+              밀어내지 않도록 lg 미만에서만 노출 */}
+          <div className="lg:hidden -mx-6 px-6 mb-6 overflow-x-auto">
+            <div className="flex gap-2 w-max">
+              {allCategories.map((category) => (
+                <button
+                  key={category.name}
+                  onClick={() => setSelectedCategory(category.name)}
+                  className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full whitespace-nowrap transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
+                    selectedCategory === category.name
+                      ? "bg-linear-to-r from-orange-400 to-red-400 text-white shadow-md"
+                      : "bg-white text-gray-700 shadow-sm"
+                  }`}
+                >
+                  <Icon
+                    name={category.icon}
+                    size={16}
+                    className={
+                      selectedCategory === category.name ? "" : "text-orange-500"
+                    }
+                  />
+                  <span>{category.name}</span>
+                  <span
+                    className={`text-xs px-1.5 rounded-full ${
+                      selectedCategory === category.name
+                        ? "bg-white/20"
+                        : "bg-orange-100 text-orange-600"
+                    }`}
+                  >
+                    {category.count}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div className="mb-8">
             <h2 className="mb-2">
               {selectedCategory === "All" ? "모든 글" : selectedCategory}

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -233,9 +233,20 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
                   {...props}
                 />
               ),
-              img: ({ ...props }) => (
-                <img className="rounded-lg my-6 w-full" {...props} />
-              ),
+              // 본문 이미지: 치수를 모르므로 반응형 패턴(width/height 0 + sizes)으로
+              // next/image 최적화(WebP·지연 로딩) 적용
+              img: ({ src, alt }) =>
+                typeof src === "string" ? (
+                  <Image
+                    src={src}
+                    alt={alt || ""}
+                    width={0}
+                    height={0}
+                    sizes="(max-width: 768px) 100vw, 768px"
+                    className="rounded-lg my-6"
+                    style={{ width: "100%", height: "auto" }}
+                  />
+                ) : null,
               hr: ({ ...props }) => (
                 <hr className="my-8 border-gray-200" {...props} />
               ),


### PR DESCRIPTION
> ⚠️ Stacked PR — base가 `feat/a11y-and-states`(#46)입니다. 머지 순서: #46 → 이 PR. **각 머지 후 Delete branch 필수** (안 하면 base 자동 정리 안 됨).

## 요약

UI/UX 개선 **3/4 — 성능 + 모바일**. #46(a11y)과 `Blog.tsx`·`BlogPost.tsx`가 겹쳐 충돌 방지를 위해 #46 위에 스택.

## 변경 내용

### 본문 이미지 최적화
- 마크다운 본문 이미지(`BlogPost.tsx`, `ProjectModal.tsx`)를 평문 `<img>` → **`next/image` 반응형 패턴**(`width/height={0}` + `sizes` + `style`)으로 전환
- 치수를 모르는 CMS 이미지에 맞는 패턴 — WebP 자동 변환 + 지연 로딩(offscreen 이미지 defer) + `remotePatterns`(기존 설정) 활용
- 남아있던 `no-img-element` 린트 경고도 해소 (헤더 로고 SVG만 의도적으로 유지)

### 모바일 카테고리 UX
- 기존: 카테고리 사이드바가 모바일에서 목록 **위에 세로로 쌓여** 첫 화면에서 글까지 스크롤이 길었음
- 변경: 모바일(lg 미만)은 **가로 스크롤 칩 바**, 데스크톱(lg+)은 기존 사이드바 유지 (`hidden lg:block` / `lg:hidden`)

## 검증
- `tsc`·ESLint **경고 0**(img 경고 포함 클리어)
- dev 실측: 모바일 칩(`lg:hidden`)·데스크톱 사이드바(`hidden lg:block`) 렌더 확인, `/blog`·포스트·`/about` 200

## 다음
4/4 다크 모드 (전 컴포넌트에 dark: 입힘 → 이 스택들 머지 후 fresh main에서 마지막에 진행 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)