### PR TITLE
[BLOG-47] Feat: 본문 이미지 next/image + 모바일 카테고리 가로 칩

### DIFF
--- a/app/blog/loading.tsx
+++ b/app/blog/loading.tsx
@@ -4,22 +4,22 @@ export default function BlogLoading() {
     <div className="max-w-7xl mx-auto px-6 py-12">
       <div className="flex flex-col lg:flex-row gap-8">
         <aside className="lg:w-64 shrink-0">
-          <div className="bg-white rounded-2xl shadow-lg p-6 h-64 animate-pulse" />
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 h-64 animate-pulse" />
         </aside>
         <div className="flex-1">
-          <div className="h-8 w-40 bg-gray-200 rounded-lg mb-8 animate-pulse" />
-          <div className="h-12 w-full bg-white rounded-full shadow-md mb-8 animate-pulse" />
+          <div className="h-8 w-40 bg-gray-200 dark:bg-gray-700 rounded-lg mb-8 animate-pulse" />
+          <div className="h-12 w-full bg-white dark:bg-gray-800 rounded-full shadow-md mb-8 animate-pulse" />
           <div className="grid md:grid-cols-2 gap-6">
             {Array.from({ length: 6 }).map((_, i) => (
               <div
                 key={i}
-                className="bg-white rounded-2xl overflow-hidden shadow-lg animate-pulse"
+                className="bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg animate-pulse"
               >
-                <div className="h-48 bg-gray-200" />
+                <div className="h-48 bg-gray-200 dark:bg-gray-700" />
                 <div className="p-6 space-y-3">
-                  <div className="h-4 w-24 bg-gray-200 rounded-full" />
-                  <div className="h-5 w-3/4 bg-gray-200 rounded" />
-                  <div className="h-4 w-full bg-gray-100 rounded" />
+                  <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded-full" />
+                  <div className="h-5 w-3/4 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div className="h-4 w-full bg-gray-100 dark:bg-gray-700/60 rounded" />
                 </div>
               </div>
             ))}

--- a/app/blog/post/[id]/loading.tsx
+++ b/app/blog/post/[id]/loading.tsx
@@ -3,19 +3,19 @@ export default function PostLoading() {
   return (
     <div className="min-h-screen">
       <div className="max-w-4xl mx-auto px-6 py-6">
-        <div className="h-6 w-32 bg-gray-200 rounded animate-pulse" />
+        <div className="h-6 w-32 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
       </div>
-      <div className="h-80 bg-gray-200 mb-12 animate-pulse" />
+      <div className="h-80 bg-gray-200 dark:bg-gray-800 mb-12 animate-pulse" />
       <div className="max-w-4xl mx-auto px-6 pb-20">
-        <div className="flex gap-2 mb-12 pb-8 border-b border-gray-200">
-          <div className="h-9 w-20 bg-gray-100 rounded-full animate-pulse" />
-          <div className="h-9 w-24 bg-gray-100 rounded-full animate-pulse" />
+        <div className="flex gap-2 mb-12 pb-8 border-b border-gray-200 dark:border-gray-700">
+          <div className="h-9 w-20 bg-gray-100 dark:bg-gray-800 rounded-full animate-pulse" />
+          <div className="h-9 w-24 bg-gray-100 dark:bg-gray-800 rounded-full animate-pulse" />
         </div>
         <div className="space-y-4">
           {Array.from({ length: 8 }).map((_, i) => (
             <div
               key={i}
-              className="h-4 bg-gray-100 rounded animate-pulse"
+              className="h-4 bg-gray-100 dark:bg-gray-800 rounded animate-pulse"
               style={{ width: `${[100, 92, 96, 70, 88, 100, 60, 84][i]}%` }}
             />
           ))}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -17,8 +17,8 @@ export default function Error({
   return (
     <div className="max-w-2xl mx-auto px-6 py-24 text-center">
       <span className="text-6xl mb-4 block">🌩️</span>
-      <h1 className="mb-3 text-gray-900">문제가 발생했어요</h1>
-      <p className="text-gray-600 mb-8 break-keep">
+      <h1 className="mb-3 text-gray-900 dark:text-gray-50">문제가 발생했어요</h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8 break-keep">
         페이지를 불러오는 중 오류가 났습니다. 잠시 후 다시 시도해 주세요.
       </p>
       <button

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,9 +39,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        {/* 첫 페인트 전에 테마 클래스를 적용해 FOUC(잘못된 테마 깜빡임) 방지 */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('theme');var d=t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches);document.documentElement.classList.toggle('dark',d);}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-linear-to-br from-orange-50 via-amber-50 to-yellow-50`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen bg-linear-to-br from-orange-50 via-amber-50 to-yellow-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-900 dark:text-gray-200`}
       >
         <JsonLd
           data={{

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,8 +7,10 @@ export default function NotFound() {
       <p className="text-7xl font-bold bg-linear-to-r from-orange-500 to-red-500 bg-clip-text text-transparent">
         404
       </p>
-      <h1 className="mt-4 mb-3 text-gray-900">페이지를 찾을 수 없어요</h1>
-      <p className="text-gray-600 mb-8 break-keep">
+      <h1 className="mt-4 mb-3 text-gray-900 dark:text-gray-50">
+        페이지를 찾을 수 없어요
+      </h1>
+      <p className="text-gray-600 dark:text-gray-400 mb-8 break-keep">
         주소가 바뀌었거나 삭제된 글일 수 있습니다. 목록에서 다시 찾아보세요.
       </p>
       <Link

--- a/components/AboutMe/HeroSection.tsx
+++ b/components/AboutMe/HeroSection.tsx
@@ -19,7 +19,7 @@ export default function HeroSection() {
             — 긍정을 전파하는 개발자
           </span>
         </h2>
-        <p className="text-gray-700 leading-relaxed break-keep max-w-2xl">
+        <p className="text-gray-700 dark:text-gray-300 leading-relaxed break-keep max-w-2xl">
           다양한 분야의 팀원들과 함께 만드는 과정을 좋아합니다. 프로젝트의
           분위기를 끌어올리는 역할을 맡아 왔고, 지금은 SW마에스트로 17기에서
           팀 프로젝트를 준비하고 있습니다.

--- a/components/AboutMe/JourneySection.tsx
+++ b/components/AboutMe/JourneySection.tsx
@@ -37,8 +37,10 @@ export default function JourneySection() {
           <div key={item.title} className="relative pb-8 last:pb-0">
             <span className="absolute -left-8 top-1.5 w-4 h-4 rounded-full bg-orange-500 ring-4 ring-orange-100" />
             <p className="text-sm font-semibold text-orange-600">{item.when}</p>
-            <h4 className="text-gray-900">{item.title}</h4>
-            <p className="text-gray-600 text-sm break-keep">{item.desc}</p>
+            <h4 className="text-gray-900 dark:text-gray-100">{item.title}</h4>
+            <p className="text-gray-600 dark:text-gray-400 text-sm break-keep">
+              {item.desc}
+            </p>
           </div>
         ))}
       </div>

--- a/components/AboutMe/ProjectModal.tsx
+++ b/components/AboutMe/ProjectModal.tsx
@@ -3,6 +3,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import { useEffect, useMemo } from "react";
 import { X } from "lucide-react";
+import Image from "next/image";
 import type { Project } from "@/lib/notion/types";
 import Icon from "@/components/icons";
 
@@ -169,9 +170,18 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
                   {...props}
                 />
               ),
-              img: ({ node, ...props }) => (
-                <img className="rounded-lg my-4 w-full" {...props} />
-              ),
+              img: ({ src, alt }) =>
+                typeof src === "string" ? (
+                  <Image
+                    src={src}
+                    alt={alt || ""}
+                    width={0}
+                    height={0}
+                    sizes="(max-width: 768px) 100vw, 700px"
+                    className="rounded-lg my-4"
+                    style={{ width: "100%", height: "auto" }}
+                  />
+                ) : null,
             }}
           >
             {memoizedContent}

--- a/components/AboutMe/ProjectModal.tsx
+++ b/components/AboutMe/ProjectModal.tsx
@@ -52,7 +52,7 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
         role="dialog"
         aria-modal="true"
         aria-label={`${project.title} 프로젝트`}
-        className="bg-white rounded-3xl max-w-3xl w-full shadow-2xl overflow-hidden my-auto"
+        className="bg-white dark:bg-gray-800 rounded-3xl max-w-3xl w-full shadow-2xl overflow-hidden my-auto"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header with gradient */}
@@ -85,13 +85,13 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
         {/* Content */}
         <div className="p-6 sm:p-8 md:p-10">
           {/* Tags */}
-          <div className="flex flex-wrap gap-2 mb-8 pb-6 border-b border-gray-200">
+          <div className="flex flex-wrap gap-2 mb-8 pb-6 border-b border-gray-200 dark:border-gray-700">
             {project.tags
               .filter((tag) => tag && tag.trim())
               .map((tag, index) => (
                 <span
                   key={`${tag}-${index}`}
-                  className="px-4 py-2 bg-orange-50 text-orange-600 rounded-full text-sm"
+                  className="px-4 py-2 bg-orange-50 text-orange-600 dark:bg-orange-500/15 dark:text-orange-300 rounded-full text-sm"
                 >
                   {tag}
                 </span>
@@ -105,28 +105,31 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
             components={{
               h2: ({ node, ...props }) => (
                 <h2
-                  className="text-2xl font-bold mt-6 mb-3 pb-2 border-b border-gray-200 text-gray-900"
+                  className="text-2xl font-bold mt-6 mb-3 pb-2 border-b border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-50"
                   {...props}
                 />
               ),
               h3: ({ node, ...props }) => (
                 <h3
-                  className="text-xl font-bold mt-6 mb-3 text-gray-800"
+                  className="text-xl font-bold mt-6 mb-3 text-gray-800 dark:text-gray-100"
                   {...props}
                 />
               ),
               p: ({ node, ...props }) => (
-                <p className="text-gray-700 leading-relaxed mb-4" {...props} />
+                <p
+                  className="text-gray-700 dark:text-gray-300 leading-relaxed mb-4"
+                  {...props}
+                />
               ),
               ul: ({ node, ...props }) => (
                 <ul
-                  className="list-disc list-inside my-4 space-y-2 text-gray-700"
+                  className="list-disc list-inside my-4 space-y-2 text-gray-700 dark:text-gray-300"
                   {...props}
                 />
               ),
               ol: ({ node, ...props }) => (
                 <ol
-                  className="list-decimal list-inside my-4 space-y-2 text-gray-700"
+                  className="list-decimal list-inside my-4 space-y-2 text-gray-700 dark:text-gray-300"
                   {...props}
                 />
               ),
@@ -145,7 +148,7 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
               }) =>
                 inline ? (
                   <code
-                    className="bg-gray-100 px-2 py-1 rounded text-sm font-mono text-gray-800"
+                    className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-sm font-mono text-gray-800 dark:text-gray-200"
                     {...props}
                   />
                 ) : (
@@ -161,7 +164,10 @@ export default function ProjectModal({ project, onClose }: ProjectModalProps) {
                 />
               ),
               strong: ({ node, ...props }) => (
-                <strong className="font-semibold text-gray-900" {...props} />
+                <strong
+                  className="font-semibold text-gray-900 dark:text-gray-100"
+                  {...props}
+                />
               ),
               a: ({ node, ...props }) => (
                 <a

--- a/components/AboutMe/ProjectsSection.tsx
+++ b/components/AboutMe/ProjectsSection.tsx
@@ -22,7 +22,7 @@ export default function ProjectsSection({
             key={project.id}
             type="button"
             aria-label={`${project.title} 프로젝트 자세히 보기`}
-            className="group relative block w-full text-left bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+            className="group relative block w-full text-left bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
             onClick={() => onProjectSelect(String(project.id))}
           >
             <div
@@ -42,8 +42,12 @@ export default function ProjectsSection({
             </div>
             <div className="p-6">
               <h4 className="mb-2">{project.title}</h4>
-              <p className="text-gray-600 mb-4">{project.period}</p>
-              <p className="text-gray-700 mb-4">{project.description}</p>
+              <p className="text-gray-600 dark:text-gray-400 mb-4">
+                {project.period}
+              </p>
+              <p className="text-gray-700 dark:text-gray-300 mb-4">
+                {project.description}
+              </p>
               <div className="flex flex-wrap gap-2">
                 {project.tags.map((tag) => (
                   <span

--- a/components/AboutMe/SkillsSection.tsx
+++ b/components/AboutMe/SkillsSection.tsx
@@ -17,10 +17,12 @@ export default function SkillsSection({ skills }: SkillsSectionProps) {
         {skills.map((skill) => (
           <div
             key={skill.name}
-            className="flex items-center gap-2.5 bg-white rounded-xl px-4 py-2.5 shadow-md hover:shadow-lg transition-shadow"
+            className="flex items-center gap-2.5 bg-white dark:bg-gray-800 rounded-xl px-4 py-2.5 shadow-md hover:shadow-lg transition-shadow"
           >
             {skill.icon}
-            <span className="font-medium text-gray-800">{skill.name}</span>
+            <span className="font-medium text-gray-800 dark:text-gray-200">
+              {skill.name}
+            </span>
           </div>
         ))}
       </div>

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -64,8 +64,8 @@ export default function Blog({ posts }: BlogProps) {
   return (
     <div className="max-w-7xl mx-auto px-6 py-12">
       <div className="flex flex-col lg:flex-row gap-8">
-        {/* Sidebar */}
-        <aside className="lg:w-64 shrink-0">
+        {/* Sidebar (데스크톱) */}
+        <aside className="hidden lg:block lg:w-64 shrink-0">
           <div className="bg-white rounded-2xl shadow-lg p-6 lg:sticky lg:top-28">
             <h3 className="mb-6 flex items-center gap-2">
               <Icon name="book" size={22} className="text-orange-500" />
@@ -110,7 +110,43 @@ export default function Blog({ posts }: BlogProps) {
         </aside>
 
         {/* Main Content */}
-        <div className="flex-1">
+        <div className="flex-1 min-w-0">
+          {/* 카테고리 (모바일) — 가로 스크롤 칩. 세로 사이드바가 목록을
+              밀어내지 않도록 lg 미만에서만 노출 */}
+          <div className="lg:hidden -mx-6 px-6 mb-6 overflow-x-auto">
+            <div className="flex gap-2 w-max">
+              {allCategories.map((category) => (
+                <button
+                  key={category.name}
+                  onClick={() => setSelectedCategory(category.name)}
+                  className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full whitespace-nowrap transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
+                    selectedCategory === category.name
+                      ? "bg-linear-to-r from-orange-400 to-red-400 text-white shadow-md"
+                      : "bg-white text-gray-700 shadow-sm"
+                  }`}
+                >
+                  <Icon
+                    name={category.icon}
+                    size={16}
+                    className={
+                      selectedCategory === category.name ? "" : "text-orange-500"
+                    }
+                  />
+                  <span>{category.name}</span>
+                  <span
+                    className={`text-xs px-1.5 rounded-full ${
+                      selectedCategory === category.name
+                        ? "bg-white/20"
+                        : "bg-orange-100 text-orange-600"
+                    }`}
+                  >
+                    {category.count}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div className="mb-8">
             <h2 className="mb-2">
               {selectedCategory === "All" ? "모든 글" : selectedCategory}

--- a/components/Blog.tsx
+++ b/components/Blog.tsx
@@ -66,7 +66,7 @@ export default function Blog({ posts }: BlogProps) {
       <div className="flex flex-col lg:flex-row gap-8">
         {/* Sidebar (데스크톱) */}
         <aside className="hidden lg:block lg:w-64 shrink-0">
-          <div className="bg-white rounded-2xl shadow-lg p-6 lg:sticky lg:top-28">
+          <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-6 lg:sticky lg:top-28">
             <h3 className="mb-6 flex items-center gap-2">
               <Icon name="book" size={22} className="text-orange-500" />
               <span>Categories</span>
@@ -79,7 +79,7 @@ export default function Blog({ posts }: BlogProps) {
                   className={`w-full flex items-center justify-between px-4 py-3 rounded-xl transition-all hover:scale-105 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                     selectedCategory === category.name
                       ? "bg-linear-to-r from-orange-400 to-red-400 text-white shadow-lg"
-                      : "bg-gray-50 text-gray-700 hover:bg-orange-50"
+                      : "bg-gray-50 text-gray-700 hover:bg-orange-50 dark:bg-gray-700/50 dark:text-gray-300 dark:hover:bg-gray-700"
                   }`}
                 >
                   <span className="flex items-center gap-2">
@@ -122,7 +122,7 @@ export default function Blog({ posts }: BlogProps) {
                   className={`shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-full whitespace-nowrap transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                     selectedCategory === category.name
                       ? "bg-linear-to-r from-orange-400 to-red-400 text-white shadow-md"
-                      : "bg-white text-gray-700 shadow-sm"
+                      : "bg-white text-gray-700 shadow-sm dark:bg-gray-800 dark:text-gray-300"
                   }`}
                 >
                   <Icon
@@ -151,7 +151,7 @@ export default function Blog({ posts }: BlogProps) {
             <h2 className="mb-2">
               {selectedCategory === "All" ? "모든 글" : selectedCategory}
             </h2>
-            <p className="text-gray-600">
+            <p className="text-gray-600 dark:text-gray-400">
               총 {filteredPosts.length}개의 포스트
             </p>
           </div>
@@ -169,7 +169,7 @@ export default function Blog({ posts }: BlogProps) {
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="제목, 태그, 내용으로 검색…"
               aria-label="블로그 글 검색"
-              className="w-full pl-11 pr-4 py-3 bg-white rounded-full shadow-md focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-400 text-gray-800 placeholder-gray-400 transition-shadow"
+              className="w-full pl-11 pr-4 py-3 bg-white dark:bg-gray-800 rounded-full shadow-md focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-orange-400 text-gray-800 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 transition-shadow"
             />
           </div>
           <div className="grid md:grid-cols-2 gap-6">
@@ -177,7 +177,7 @@ export default function Blog({ posts }: BlogProps) {
               <Link
                 key={post.id}
                 href={postPath(post)}
-                className="group relative block bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+                className="group relative block bg-white dark:bg-gray-800 rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:-translate-y-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               >
                 <article>
                   <div
@@ -209,7 +209,7 @@ export default function Blog({ posts }: BlogProps) {
                       <span className="px-3 py-1 bg-orange-100 text-orange-600 rounded-full text-sm">
                         {post.category}
                       </span>
-                      <span className="text-gray-500 text-sm">
+                      <span className="text-gray-500 dark:text-gray-400 text-sm">
                         읽는데 {post.readTime}분
                       </span>
                     </div>
@@ -218,12 +218,14 @@ export default function Blog({ posts }: BlogProps) {
                       {post.title}
                     </h4>
 
-                    <p className="text-gray-600 mb-4 line-clamp-2">
+                    <p className="text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">
                       {post.excerpt}
                     </p>
 
                     <div className="flex items-center justify-between">
-                      <span className="text-gray-500 text-sm">{post.date}</span>
+                      <span className="text-gray-500 dark:text-gray-400 text-sm">
+                        {post.date}
+                      </span>
                       <span className="text-orange-600 group-hover:gap-2 flex items-center gap-1 transition-all">
                         <span>더 보기</span>
                         <span>→</span>
@@ -234,7 +236,7 @@ export default function Blog({ posts }: BlogProps) {
                       {post.tags.map((tag) => (
                         <span
                           key={tag}
-                          className="px-2 py-1 bg-gray-100 text-gray-600 rounded-md text-sm"
+                          className="px-2 py-1 bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300 rounded-md text-sm"
                         >
                           #{tag}
                         </span>

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -145,11 +145,11 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
         transition={{ delay: 0.3 }}
       >
         {/* Tags */}
-        <div className="flex flex-wrap gap-2 mb-12 pb-8 border-b border-gray-200">
+        <div className="flex flex-wrap gap-2 mb-12 pb-8 border-b border-gray-200 dark:border-gray-700">
           {post.tags.map((tag) => (
             <motion.span
               key={tag}
-              className="px-4 py-2 bg-orange-50 text-orange-600 rounded-full hover:bg-orange-100 transition-colors cursor-pointer"
+              className="px-4 py-2 bg-orange-50 text-orange-600 dark:bg-orange-500/15 dark:text-orange-300 rounded-full hover:bg-orange-100 dark:hover:bg-orange-500/25 transition-colors cursor-pointer"
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >
@@ -166,40 +166,43 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
             components={{
               h1: ({ ...props }) => (
                 <h1
-                  className="text-4xl font-bold mt-8 mb-4 text-gray-900"
+                  className="text-4xl font-bold mt-8 mb-4 text-gray-900 dark:text-gray-50"
                   {...props}
                 />
               ),
               h2: ({ ...props }) => (
                 <h2
-                  className="text-3xl font-bold mt-8 mb-4 pb-2 border-b border-gray-200 text-gray-900"
+                  className="text-3xl font-bold mt-8 mb-4 pb-2 border-b border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-50"
                   {...props}
                 />
               ),
               h3: ({ ...props }) => (
                 <h3
-                  className="text-2xl font-bold mt-6 mb-3 text-gray-800"
+                  className="text-2xl font-bold mt-6 mb-3 text-gray-800 dark:text-gray-100"
                   {...props}
                 />
               ),
               p: ({ ...props }) => (
-                <p className="text-gray-700 leading-relaxed mb-6" {...props} />
+                <p
+                  className="text-gray-700 dark:text-gray-300 leading-relaxed mb-6"
+                  {...props}
+                />
               ),
               ul: ({ ...props }) => (
                 <ul
-                  className="list-disc list-inside my-6 space-y-2 text-gray-700"
+                  className="list-disc list-inside my-6 space-y-2 text-gray-700 dark:text-gray-300"
                   {...props}
                 />
               ),
               ol: ({ ...props }) => (
                 <ol
-                  className="list-decimal list-inside my-6 space-y-2 text-gray-700"
+                  className="list-decimal list-inside my-6 space-y-2 text-gray-700 dark:text-gray-300"
                   {...props}
                 />
               ),
               blockquote: ({ ...props }) => (
                 <blockquote
-                  className="border-l-4 border-orange-400 bg-orange-50 py-4 px-6 rounded-r-lg my-6 text-gray-800 italic"
+                  className="border-l-4 border-orange-400 bg-orange-50 dark:bg-orange-500/10 py-4 px-6 rounded-r-lg my-6 text-gray-800 dark:text-gray-200 italic"
                   {...props}
                 />
               ),
@@ -215,7 +218,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
               }) =>
                 inline ? (
                   <code
-                    className="bg-gray-100 px-2 py-1 rounded text-sm font-mono text-gray-800"
+                    className="bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded text-sm font-mono text-gray-800 dark:text-gray-200"
                     {...props}
                   >
                     {children}
@@ -248,7 +251,10 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
                   />
                 ) : null,
               hr: ({ ...props }) => (
-                <hr className="my-8 border-gray-200" {...props} />
+                <hr
+                  className="my-8 border-gray-200 dark:border-gray-700"
+                  {...props}
+                />
               ),
               table: ({ ...props }) => (
                 <div className="overflow-x-auto my-6">
@@ -256,22 +262,31 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
                 </div>
               ),
               thead: ({ ...props }) => (
-                <thead className="bg-gray-50" {...props} />
+                <thead className="bg-gray-50 dark:bg-gray-800" {...props} />
               ),
               tbody: ({ ...props }) => (
-                <tbody className="divide-y divide-gray-200" {...props} />
+                <tbody
+                  className="divide-y divide-gray-200 dark:divide-gray-700"
+                  {...props}
+                />
               ),
               tr: ({ ...props }) => (
-                <tr className="border-b border-gray-200" {...props} />
+                <tr
+                  className="border-b border-gray-200 dark:border-gray-700"
+                  {...props}
+                />
               ),
               th: ({ ...props }) => (
                 <th
-                  className="px-4 py-2 text-left font-semibold text-gray-900"
+                  className="px-4 py-2 text-left font-semibold text-gray-900 dark:text-gray-100"
                   {...props}
                 />
               ),
               td: ({ ...props }) => (
-                <td className="px-4 py-2 text-gray-700" {...props} />
+                <td
+                  className="px-4 py-2 text-gray-700 dark:text-gray-300"
+                  {...props}
+                />
               ),
             }}
           >
@@ -280,17 +295,19 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
         </div>
 
         {/* Actions */}
-        <div className="mt-16 pt-8 border-t border-gray-200">
+        <div className="mt-16 pt-8 border-t border-gray-200 dark:border-gray-700">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <p className="text-gray-600">이 글이 도움이 되셨나요?</p>
+            <p className="text-gray-600 dark:text-gray-400">
+              이 글이 도움이 되셨나요?
+            </p>
             <div className="flex gap-3">
               <motion.button
                 onClick={handleLike}
                 disabled={isLiking}
                 className={`px-6 py-2 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
                   hasLiked
-                    ? "bg-orange-200 text-orange-700 hover:bg-orange-300"
-                    : "bg-orange-100 text-orange-600 hover:bg-orange-200"
+                    ? "bg-orange-200 text-orange-700 hover:bg-orange-300 dark:bg-orange-500/30 dark:text-orange-200"
+                    : "bg-orange-100 text-orange-600 hover:bg-orange-200 dark:bg-orange-500/15 dark:text-orange-300 dark:hover:bg-orange-500/25"
                 }`}
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
@@ -307,7 +324,7 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
               </motion.button>
               <motion.button
                 onClick={handleShare}
-                className="px-6 py-2 bg-gray-100 text-gray-700 rounded-full hover:bg-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+                className="px-6 py-2 bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
               >
@@ -333,10 +350,10 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
             {olderPost ? (
               <Link
                 href={postPath(olderPost)}
-                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+                className="group bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               >
                 <p className="text-sm text-gray-500 mb-1">← 이전 글</p>
-                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                <p className="text-gray-800 dark:text-gray-200 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
                   {olderPost.title}
                 </p>
               </Link>
@@ -346,10 +363,10 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
             {newerPost && (
               <Link
                 href={postPath(newerPost)}
-                className="group bg-white rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 text-right"
+                className="group bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-md hover:shadow-lg transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 text-right"
               >
                 <p className="text-sm text-gray-500 mb-1">다음 글 →</p>
-                <p className="text-gray-800 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
+                <p className="text-gray-800 dark:text-gray-200 group-hover:text-orange-600 transition-colors line-clamp-1 break-keep">
                   {newerPost.title}
                 </p>
               </Link>
@@ -358,8 +375,8 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
         )}
 
         {/* Comments */}
-        <div className="mt-16 pt-8 border-t border-gray-200">
-          <h3 className="mb-6 flex items-center gap-2 text-gray-800">
+        <div className="mt-16 pt-8 border-t border-gray-200 dark:border-gray-700">
+          <h3 className="mb-6 flex items-center gap-2 text-gray-800 dark:text-gray-100">
             <Icon name="chat" size={20} className="text-orange-500" />
             <span>댓글</span>
           </h3>

--- a/components/BlogPost.tsx
+++ b/components/BlogPost.tsx
@@ -233,9 +233,20 @@ export default function BlogPost({ post, newerPost, olderPost }: Props) {
                   {...props}
                 />
               ),
-              img: ({ ...props }) => (
-                <img className="rounded-lg my-6 w-full" {...props} />
-              ),
+              // 본문 이미지: 치수를 모르므로 반응형 패턴(width/height 0 + sizes)으로
+              // next/image 최적화(WebP·지연 로딩) 적용
+              img: ({ src, alt }) =>
+                typeof src === "string" ? (
+                  <Image
+                    src={src}
+                    alt={alt || ""}
+                    width={0}
+                    height={0}
+                    sizes="(max-width: 768px) 100vw, 768px"
+                    className="rounded-lg my-6"
+                    style={{ width: "100%", height: "auto" }}
+                  />
+                ) : null,
               hr: ({ ...props }) => (
                 <hr className="my-8 border-gray-200" {...props} />
               ),

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -15,9 +15,14 @@ const GISCUS_CONFIG: Record<string, string> = {
   "data-reactions-enabled": "1",
   "data-emit-metadata": "0",
   "data-input-position": "top",
-  "data-theme": "light",
   "data-lang": "ko",
 };
+
+function giscusTheme(): string {
+  return document.documentElement.classList.contains("dark")
+    ? "dark_dimmed"
+    : "light";
+}
 
 export default function Comments({ term }: { term: string }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -34,10 +39,23 @@ export default function Comments({ term }: { term: string }) {
       script.setAttribute(key, value)
     );
     script.setAttribute("data-term", term);
+    script.setAttribute("data-theme", giscusTheme());
     el.appendChild(script);
 
-    // 포스트 간 이동 시 이전 위젯 정리 (pathname 매핑이 새로 잡히도록)
+    // 사이트 테마 토글 시 giscus iframe에 테마 변경을 postMessage로 전달
+    const onThemeChange = () => {
+      const iframe =
+        el.querySelector<HTMLIFrameElement>("iframe.giscus-frame");
+      iframe?.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme: giscusTheme() } } },
+        "https://giscus.app"
+      );
+    };
+    window.addEventListener("themechange", onThemeChange);
+
+    // 포스트 간 이동 시 이전 위젯 정리 (term 매핑이 새로 잡히도록)
     return () => {
+      window.removeEventListener("themechange", onThemeChange);
       el.innerHTML = "";
     };
   }, [term]);

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -19,10 +19,10 @@ export default function Footer() {
     // data-nosnippet: 검색엔진이 푸터 텍스트를 스니펫으로 쓰지 못하게
     <footer
       data-nosnippet=""
-      className="mt-20 bg-linear-to-r from-orange-100 to-amber-100 py-12"
+      className="mt-20 bg-linear-to-r from-orange-100 to-amber-100 dark:from-gray-900 dark:to-gray-900 dark:border-t dark:border-gray-800 py-12"
     >
       <div className="max-w-7xl mx-auto px-6 text-center">
-        <p className="text-gray-700">
+        <p className="text-gray-700 dark:text-gray-400">
           © {new Date().getFullYear()} JSChoIog. Built with passion and
           dedication 🚀
         </p>
@@ -33,7 +33,7 @@ export default function Footer() {
               href={link.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="relative w-10 h-10 bg-white rounded-full flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all group focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+              className="relative w-10 h-10 bg-white dark:bg-gray-800 rounded-full flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all group focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
               title={link.label}
             >
               <Icon name={link.icon} size={18} className="text-orange-600" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import ThemeToggle from "@/components/ThemeToggle";
 
 export default function Header() {
   const pathname = usePathname();
@@ -13,7 +14,7 @@ export default function Header() {
     // data-nosnippet: 검색엔진이 헤더 텍스트를 스니펫으로 쓰지 못하게
     <header
       data-nosnippet=""
-      className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-orange-100"
+      className="fixed top-0 left-0 right-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-lg border-b border-orange-100 dark:border-gray-800"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between gap-2">
         <Link
@@ -29,13 +30,14 @@ export default function Header() {
           </h1>
         </Link>
 
-        <nav className="flex gap-1 sm:gap-2 shrink-0">
+        <nav className="flex items-center gap-1 sm:gap-2 shrink-0">
           <NavLink active={isBlog} href="/blog">
             Blog
           </NavLink>
           <NavLink active={isAbout} href="/about">
             About Me
           </NavLink>
+          <ThemeToggle />
         </nav>
       </div>
     </header>
@@ -57,7 +59,7 @@ function NavLink({
       className={`px-4 sm:px-6 py-2 rounded-full transition-all hover:scale-105 active:scale-95 inline-flex items-center justify-center whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2 ${
         active
           ? "bg-linear-to-r from-orange-500 to-red-500 text-white shadow-lg"
-          : "text-gray-700 hover:bg-orange-50"
+          : "text-gray-700 hover:bg-orange-50 dark:text-gray-300 dark:hover:bg-gray-800"
       }`}
       aria-current={active ? "page" : undefined}
     >

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { Moon, Sun } from "lucide-react";
+
+// html.dark 클래스(외부 상태)를 구독. 토글은 클래스 변경 + localStorage 저장 후
+// themechange 이벤트를 발행하고, giscus 등 다른 위젯이 이를 구독한다.
+function subscribe(callback: () => void) {
+  window.addEventListener("themechange", callback);
+  return () => window.removeEventListener("themechange", callback);
+}
+function getSnapshot() {
+  return document.documentElement.classList.contains("dark");
+}
+function getServerSnapshot() {
+  return false; // 서버에서는 라이트 기준 (실제 테마는 FOUC 스크립트가 이미 적용)
+}
+
+export default function ThemeToggle() {
+  const dark = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const toggle = () => {
+    const next = !dark;
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+    window.dispatchEvent(new CustomEvent("themechange"));
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={dark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      className="w-10 h-10 shrink-0 rounded-full flex items-center justify-center text-gray-600 hover:bg-orange-50 dark:text-gray-300 dark:hover:bg-gray-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-2"
+    >
+      {dark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </button>
+  );
+}


### PR DESCRIPTION
> ✅ main 기반 **독립 PR** (스택 아님). 머지 후 Delete branch만 눌러주세요.

## 요약

UI/UX 개선 **4/4 — 다크 모드**. 브라우저로 라이트↔다크 전환을 실제 검증했습니다.

**추가로**: 지난 스택 머지 사고로 **#47(본문 next/image·모바일 카테고리 칩)이 main에 누락**돼 있어(자기 base 브랜치에만 머지됨), 이 브랜치에 해당 커밋을 cherry-pick으로 복구해 함께 반영합니다. (삭제된 배포 워크플로 #45는 되살아나지 않도록 커밋만 골라옴)

## 다크 모드 구현

- **테마 토글** (`ThemeToggle.tsx`): 헤더에 해/달 버튼. `html.dark` 클래스 토글 + `localStorage` 저장. `useSyncExternalStore`로 외부 상태 구독(린트/하이드레이션 안전), `themechange` 커스텀 이벤트 발행
- **FOUC 방지**: `layout`의 `<head>`에 첫 페인트 전 테마를 적용하는 인라인 스크립트 → 새로고침 시 깜빡임 없음. 최초 방문은 OS `prefers-color-scheme` 따름
- **전 표면 `dark:` 변형**: 헤더·푸터, 블로그 카드/사이드바/검색/카테고리 칩, 포스트 본문(prose·코드·표·인용구)·좋아요/공유·이전다음·댓글 헤딩, About 히어로/여정/스킬/프로젝트/모달, 로딩 스켈레톤·404·에러
- **giscus 테마 동기화**: 댓글 위젯을 사이트 테마에 맞춤(`dark_dimmed`), 토글 시 `postMessage`로 실시간 전환
- 이미 있던(사용 안 되던) `globals.css` 다크 인프라를 실제로 활성화

## 검증 (Chrome 실측)
- 블로그 목록: 라이트/다크 모두 정상 — 오렌지 브랜드 액센트 유지, 텍스트 대비 양호
- 포스트: 본문 prose·코드 블록(다크 하이라이팅)·버튼·이전/다음·**giscus 댓글 다크 동기화** 확인
- 토글 동작 + localStorage 지속 확인
- `tsc`·ESLint 통과

이로써 UI/UX 개선 4종(코드블록·접근성/상태·성능/모바일·다크모드) 전부 완료됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 🔗 Related Issue

  <!-- ⚠️ 아래 내용은 자동으로 채워집니다. 수정하지 마세요 -->

  Closes #47

  > Feat: 본문 이미지 next/image + 모바일 카테고리 가로 칩